### PR TITLE
Added the ability to delete user with uid

### DIFF
--- a/lib/validic/request.rb
+++ b/lib/validic/request.rb
@@ -23,11 +23,15 @@ module Validic
       request(:put, path, options)
     end
 
+    def delete(path, options)
+      request(:delete, path, options)
+    end
+
     def request(method, path, options)
       options[:access_token] = options[:access_token].nil? ? Validic.access_token : options[:access_token]
       response = connection.send(method) do |request|
         case method
-        when :get
+        when :get, :delete
           request.url(path, options)
         when :post, :put
           request.path = path

--- a/lib/validic/user.rb
+++ b/lib/validic/user.rb
@@ -5,7 +5,7 @@ module Validic
 
     ##
     # Get Users base on `access_token` and organization_id
-    # 
+    #
     # @params :status - optional (active or inactive) default :all
     # @params :access_token - optional
     # @params :start_date - optional
@@ -21,7 +21,7 @@ module Validic
 
     ##
     # Get User id base on `access_token`
-    # 
+    #
     # @return id
     def me(options={})
       options = {
@@ -81,6 +81,22 @@ module Validic
       }
 
       response = put("/#{Validic.api_version}/organizations/#{organization_id}/users/#{user_id}.json", options)
+      response
+    end
+
+    ##
+    #
+    # DELETE request for deleting a user
+    #
+    # @params[:organization_id] -- String
+    # @params[:access_token] -- String -- organization's access_token
+    # @params[:uid] -- String -- user's ID to suspend
+    #
+    # @return [Hashie::Mash] with response
+    def user_delete(options={})
+      organization_id = options[:organization_id]
+
+      response = delete("/#{Validic.api_version}/organizations/#{organization_id}/users.json", options)
       response
     end
   end

--- a/lib/validic/version.rb
+++ b/lib/validic/version.rb
@@ -1,3 +1,3 @@
 module Validic
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end

--- a/spec/validic/user_spec.rb
+++ b/spec/validic/user_spec.rb
@@ -68,4 +68,14 @@ describe Validic::User do
     end
   end
 
+  context "#user_delete" do
+    it "should delete a user" do
+      pending
+      @delete_user = client.user_delete(organization_id: "51aca5a06dedda916400002b",
+                                        uid: ENV['TEST_USER_ID'],
+                                        access_token: "9c03ad2bcb022425944e4686d398ef8398f537c2f7c113495ffa7bc9cfa49286")
+      @delete_user.status.should eq 200
+    end
+  end
+
 end


### PR DESCRIPTION
# Summary

Added the ability to delete a user using their `uid` assigned by the consumer of the API. This update only uses the secondary way of deleting a user using this url format:

`DELETE https://api.validic.com/v1/organizations/5176906c6deddac02c000001/users.json`

Also added delete ability to `Validic::Request` module.

NOTE: Was unsure how to test user `user_delete` method correctly since most specs seem to be pending.
