### PR TITLE
Add expanded filter for org_apps

### DIFF
--- a/lib/validic/rest/apps.rb
+++ b/lib/validic/rest/apps.rb
@@ -4,8 +4,8 @@ module Validic
   module REST
     module Apps
 
-      def get_org_apps
-        resp = get_request(:apps)
+      def get_org_apps(params = {})
+        resp = get_request(:apps, params)
         build_response_attr(resp)
       end
       alias :get_apps :get_org_apps

--- a/spec/validic/rest/apps_spec.rb
+++ b/spec/validic/rest/apps_spec.rb
@@ -4,19 +4,38 @@ describe Validic::REST::Apps do
   let(:client) { Validic::Client.new }
 
   describe "#get_apps" do
-    before do
-      stub_get("/organizations/1/apps.json")
-        .with(query: { access_token: '1' })
-        .to_return(body: fixture('apps.json'),
-      headers: { content_type: 'application/json; charset=utf-8' })
-        @apps = client.get_org_apps
+    context 'non-expanded' do
+      before do
+        stub_get("/organizations/1/apps.json")
+          .with(query: { access_token: '1' })
+          .to_return(body: fixture('apps.json'),
+        headers: { content_type: 'application/json; charset=utf-8' })
+          @apps = client.get_org_apps
+      end
+
+      it 'returns a response object' do
+        expect(@apps).to be_a Validic::Response
+      end
+      it 'makes an apps request to the correct url' do
+        expect(a_get('/organizations/1/apps.json')
+          .with(query: { access_token: '1' })).to have_been_made
+      end
     end
-    it 'returns a response object' do
-      expect(@apps).to be_a Validic::Response
-    end
-    it 'makes an apps request to the correct url' do
-      expect(a_get('/organizations/1/apps.json')
-        .with(query: { access_token: '1' })).to have_been_made
+    context 'expanded' do
+      before do
+        stub_get("/organizations/1/apps.json")
+          .with(query: { access_token: '1', expanded: 1 })
+          .to_return(body: fixture('apps.json'),
+        headers: { content_type: 'application/json; charset=utf-8' })
+          @apps = client.get_org_apps(expanded: 1)
+      end
+      it 'returns a response object' do
+        expect(@apps).to be_a Validic::Response
+      end
+      it 'makes an apps request to the correct url' do
+        expect(a_get('/organizations/1/apps.json')
+          .with(query: { access_token: '1', expanded: '1' })).to have_been_made
+      end
     end
   end
 
@@ -26,7 +45,7 @@ describe Validic::REST::Apps do
         .with(query: { authentication_token: '2', access_token: '1' })
         .to_return(body: fixture('synced_apps.json'),
       headers: { content_type: 'application/json; charset=utf-8' })
-      @synced_apps = client.get_user_synced_apps(authentication_token: '2')
+        @synced_apps = client.get_user_synced_apps(authentication_token: '2')
     end
     it 'returns a response object' do
       expect(@synced_apps).to be_a Validic::Response


### PR DESCRIPTION
This change was brought up in issue #20 

Previously the wrapper did not support the expanded filter that we
outline [in our docs](https://validic.com/api#1716), enabling customers to get extra fields for certain
applications.