### PR TITLE
Error checks added for invalid date response

### DIFF
--- a/lib/validic/error.rb
+++ b/lib/validic/error.rb
@@ -9,11 +9,13 @@ module Validic
     UnprocessableEntity = Class.new(ClientError)
     Conflict = Class.new(ClientError)
     InternalServerError = Class.new(ServerError)
+    InvalidDate = Class.new(ClientError)
 
     ERRORS = {
       401 => Validic::Error::Unauthorized,
       403 => Validic::Error::Forbidden,
       404 => Validic::Error::NotFound,
+      406 => Validic::Error::InvalidDate,
       409 => Validic::Error::Conflict,
       422 => Validic::Error::UnprocessableEntity,
       500 => Validic::Error::InternalServerError

--- a/spec/fixtures/invalid_date.json
+++ b/spec/fixtures/invalid_date.json
@@ -1,0 +1,1 @@
+{"code": 406, "message": "Not Acceptable", "errors": ["Invalid date"]}

--- a/spec/validic/error_spec.rb
+++ b/spec/validic/error_spec.rb
@@ -70,4 +70,20 @@ describe Validic::Error do
       expect { client.get_profile }.to raise_error(Validic::Error::Unauthorized)
     end
   end
+
+  context 'Invalid date' do
+    before do
+      stub_request(:get, /fitness/)
+        .to_return(status: 406, body: fixture('invalid_date.json'),
+                   headers: { content_type: 'application/json; charset=utf-8' })
+    end
+    it 'raises an InvalidDate error' do
+      start_date = DateTime.new(2015, 07, 15, 12)
+      end_date = DateTime.new(2015, 07, 15, 13)
+
+      expect {
+        client.get_fitness(start_date: start_date, end_date: end_date)
+      }.to raise_error Validic::Error::InvalidDate
+    end
+  end
 end


### PR DESCRIPTION
This change will enable users of the gem to see any invalid date errors
(code 406) raised by the gem itself.  Currently the gem is trying to
take this parsed response and build objects out of them, see issue #22
for details.