### PR TITLE
Client configuration hotfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,6 @@ client.get_routine(start_date: '2015-01-01T00:00:00+00:00')
 
 ### More Examples ###
 
-You can override initialized organization_id and access tokens for all helper
-methods by passing parameters in an options hash as a final parameter.
-
 Below are examples of all helper methods.
 
 ```ruby

--- a/lib/validic/client.rb
+++ b/lib/validic/client.rb
@@ -48,6 +48,7 @@ module Validic
       @api_version      = options.fetch(:api_version, 'v1')
       @access_token     = options.fetch(:access_token, Validic.access_token)
       @organization_id  = options.fetch(:organization_id, Validic.organization_id)
+      reload_config
     end
 
     ##


### PR DESCRIPTION
- Make sure `reload_config` is called after `Client.new` is instantiated
- This is a hotfix as we'll likely want to make sure all options into
  `construct_path` are consistent so overrides are easier to understand
  (ie organization_id, access_token)
- We should better document how overrides should be used
- We should better document how customers with multiple organizations
  should interface with the gem.