### PR TITLE
Include data pull by using the next/previous url from summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ You can pass a hash of options to calls that fetch data.
 client.get_routine(start_date: '2015-01-01T00:00:00+00:00')
 ```
 
+Pull data by using the next or previous urls
+```ruby
+client.pull_via_url("next_url/previous_url")
+```
+
 ### More Examples ###
 
 Below are examples of all helper methods.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ client.get_routine(start_date: '2015-01-01T00:00:00+00:00')
 
 Pull data by using the next or previous urls
 ```ruby
-client.pull_via_url("next_url/previous_url")
+response = client.get_routine(start_date: '2015-01-01')
+client.pull_via_url(response.summary.next)
 ```
 
 ### More Examples ###

--- a/lib/validic/rest/request.rb
+++ b/lib/validic/rest/request.rb
@@ -15,6 +15,16 @@ module Validic
         get(path, options)
       end
 
+      def pull_via_url(path, options = {})
+        return nil if path.nil?
+        if path.include?("page")
+          resp = get(path, options)
+          build_response_attr(resp)
+        else
+          "Page number required"
+        end
+      end
+
       private
 
       def get_request(type, options = {})

--- a/lib/validic/version.rb
+++ b/lib/validic/version.rb
@@ -1,3 +1,3 @@
 module Validic
-  VERSION = '0.4.1'
+  VERSION = '0.4.2'
 end

--- a/spec/fixtures/routines_page2.json
+++ b/spec/fixtures/routines_page2.json
@@ -2,13 +2,13 @@
   "summary": {
     "status": 200,
     "message": "OK",
-    "results": 3,
+    "results": 2,
     "start_date": "2013-03-27T00:00:00+00:00",
     "end_date": "2013-03-27T23:59:59+00:00",
     "offset": 0,
     "limit": 100,
-    "previous": null,
-    "next": "https://api.validic.com/v1/organizations/1/routine.json?access_token=e7aefafcac801b320f79fafcf46d3090b6b5fda9e71ddb374c9c1223a5843adc&start_date=2013-01-01&page=2",
+    "previous": "https://api.validic.com/v1/organizations/1/routine.json?access_token=1&start_date=2013-01-01&page=1",
+    "next": null,
     "params": {
       "start_date": null,
       "end_date": null,
@@ -18,29 +18,29 @@
   },"routine": [
     {
     "_id": "51552cdbfded0807c4000062",
-    "timestamp": "2013-03-10T07:12:16+00:00",
+    "timestamp": "2013-03-27T07:12:16+00:00",
     "utc_offset": "+00:00",
-    "steps": 9355,
-    "distance": 7290.33,
-    "floors": 23,
+    "steps": 6412,
+    "distance": 4589.21,
+    "floors": 16,
     "elevation": 3.4,
     "calories_burned": 2874,
     "source": "sample_app",
     "source_name": "Sample App",
-    "last_updated": "2013-03-10T07:12:16+00:00"
+    "last_updated": "2013-03-27T07:12:16+00:00"
   },
   {
     "_id": "51552cdbfded0807c4000062",
-    "timestamp": "2013-03-10T07:12:16+00:00",
+    "timestamp": "2013-03-27T07:12:16+00:00",
     "utc_offset": "+00:00",
-    "steps": 9355,
-    "distance": 7290.33,
-    "floors": 23,
+    "steps": 3333,
+    "distance": 3422.33,
+    "floors": 10,
     "elevation": 3.4,
-    "calories_burned": 2874,
+    "calories_burned": 1532,
     "source": "sample_app",
     "source_name": "Sample App",
-    "last_updated": "2013-03-10T07:12:16+00:00"
+    "last_updated": "2013-03-27T07:12:16+00:00"
   }
   ]
 }

--- a/spec/validic/rest/request_spec.rb
+++ b/spec/validic/rest/request_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Validic::REST::Request do
+  let(:client) { Validic::Client.new }
+
+  describe "#pull_via_url" do
+    before do
+      stub_get('/organizations/1/routine.json')
+        .with(query: { access_token: '1' })
+        .to_return(body: fixture('routines.json'),
+      headers: { content_type: 'application/json; charset=utf-8' })
+      stub_get('/organizations/1/routine.json')
+        .with(query: { access_token: '1', page: '2', start_date: '2013-01-01' })
+        .to_return(body: fixture('routines_page2.json'),
+      headers: { content_type: 'application/json; charset=utf-8' })
+    end
+    it "returns data using the next value of the summary response" do
+      routine = client.get_routine
+      expect(routine).to be_a Validic::Response
+      pull_next = client.pull_via_url routine.summary.next
+      expect(pull_next).to be_a Validic::Response
+      expect(pull_next.records).to be_kind_of Array
+    end
+  end
+end


### PR DESCRIPTION
By using the next or previous url on get_{endpoint} responses, this will enable pulling of data by passing the url