### PR TITLE
Paginated request

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    validic (0.4.1)
+    validic (0.4.2)
       faraday_middleware (~> 0.9.0)
       multi_json
 
@@ -18,7 +18,7 @@ GEM
     faraday_middleware (0.9.1)
       faraday (>= 0.7.4, < 0.10)
     method_source (0.8.2)
-    multi_json (1.11.0)
+    multi_json (1.11.2)
     multipart-post (2.0.0)
     pry (0.10.1)
       coderay (~> 1.1.0)

--- a/README.md
+++ b/README.md
@@ -457,6 +457,11 @@ client.delete_tobacco_cessation(user_id: 'VALIDIC_USER_ID', _id: 'VALIDIC_ACTIVI
 client.create_fitness(user_id: 'VALIDIC_USER_ID', activity_id: 'UNIQUE_ACTIVITY_ID', extras: "{\"stars\": 3}")
 ```
 
+##### Get an endpoints first 2000 endpoint records
+``` ruby
+client.get_routine(start_date: '2015-01-01', paginated: "true")
+```
+
 ##   [Latest Records](https://validic.com/api/bulkdata/#latest)
 
 ###### You can also pass an options hash to filter latest results

--- a/lib/validic/version.rb
+++ b/lib/validic/version.rb
@@ -1,3 +1,3 @@
 module Validic
-  VERSION = '0.4.1'
+  VERSION = '0.4.2'
 end

--- a/spec/validic/rest/biometrics_spec.rb
+++ b/spec/validic/rest/biometrics_spec.rb
@@ -37,6 +37,19 @@ describe Validic::REST::Biometrics do
         expect(a_get('/organizations/1/users/1/biometrics.json').with(query: { access_token: '1' })).to have_been_made
       end
     end
+    context 'paginated true' do
+      before do
+        stub_get("/organizations/1/biometrics.json")
+          .with(query: { access_token: '1', paginated: "true" })
+          .to_return(body: fixture('biometrics_records.json'),
+        headers: { content_type: 'application/json; charset=utf-8' })
+      end
+      it 'returns a Validic Response' do
+        biometrics_record = client.get_biometrics(access_token: '1', paginated: "true")
+        expect(biometrics_record).to be_a Validic::Response
+        expect(biometrics_record.summary.limit).to eq 2_000
+      end
+    end
   end
 
   describe '#create_biometrics' do

--- a/spec/validic/rest/diabetes_spec.rb
+++ b/spec/validic/rest/diabetes_spec.rb
@@ -37,6 +37,19 @@ describe Validic::REST::Diabetes do
         expect(a_get('/organizations/1/users/1/diabetes.json').with(query: { access_token: '1' })).to have_been_made
       end
     end
+    context 'paginated true' do
+      before do
+        stub_get("/organizations/1/diabetes.json")
+          .with(query: { access_token: '1', paginated: "true" })
+          .to_return(body: fixture('diabetes_records.json'),
+        headers: { content_type: 'application/json; charset=utf-8' })
+      end
+      it 'returns a Validic Response' do
+        diabetes_record = client.get_diabetes(access_token: '1', paginated: "true")
+        expect(diabetes_record).to be_a Validic::Response
+        expect(diabetes_record.summary.limit).to eq 2_000
+      end
+    end
   end
 
   describe '#create_diabetes' do

--- a/spec/validic/rest/fitness_spec.rb
+++ b/spec/validic/rest/fitness_spec.rb
@@ -37,6 +37,19 @@ describe Validic::REST::Fitness do
         expect(a_get('/organizations/1/users/1/fitness.json').with(query: { access_token: '1' })).to have_been_made
       end
     end
+    context 'paginated true' do
+      before do
+        stub_get("/organizations/1/fitness.json")
+          .with(query: { access_token: '1', paginated: "true" })
+          .to_return(body: fixture('fitnesses.json'),
+        headers: { content_type: 'application/json; charset=utf-8' })
+      end
+      it 'returns a Validic Response' do
+        fitnesses_record = client.get_fitnesses(access_token: '1', paginated: "true")
+        expect(fitnesses_record).to be_a Validic::Response
+        expect(fitnesses_record.summary.limit).to eq 2_000
+      end
+    end
   end
 
   describe '#create_fitness' do

--- a/spec/validic/rest/nutrition_spec.rb
+++ b/spec/validic/rest/nutrition_spec.rb
@@ -40,6 +40,19 @@ describe Validic::REST::Nutrition do
           .to have_been_made
       end
     end
+    context 'paginated true' do
+      before do
+        stub_get("/organizations/1/nutrition.json")
+          .with(query: { access_token: '1', paginated: "true" })
+          .to_return(body: fixture('nutritions.json'),
+        headers: { content_type: 'application/json; charset=utf-8' })
+      end
+      it 'returns a Validic Response' do
+        nutritions_records = client.get_nutrition(access_token: '1', paginated: "true")
+        expect(nutritions_records).to be_a Validic::Response
+        expect(nutritions_records.summary.limit).to eq 2_000
+      end
+    end
   end
 
   describe '#create_nutrition' do

--- a/spec/validic/rest/routine_spec.rb
+++ b/spec/validic/rest/routine_spec.rb
@@ -35,6 +35,19 @@ describe Validic::REST::Routine do
         expect(a_get('/organizations/1/users/1/routine.json').with(query: { access_token: '1' })).to have_been_made
       end
     end
+    context 'paginated true' do
+      before do
+        stub_get("/organizations/1/routine.json")
+          .with(query: { access_token: '1', paginated: "true" })
+          .to_return(body: fixture('routines.json'),
+        headers: { content_type: 'application/json; charset=utf-8' })
+      end
+      it 'returns a Validic Response' do
+        routine_records = client.get_routine(access_token: '1', paginated: "true")
+        expect(routine_records).to be_a Validic::Response
+        expect(routine_records.summary.limit).to eq 2_000
+      end
+    end
   end
 
   describe '#create_routine' do

--- a/spec/validic/rest/sleep_spec.rb
+++ b/spec/validic/rest/sleep_spec.rb
@@ -36,6 +36,19 @@ describe Validic::REST::Sleep do
         expect(a_get('/organizations/1/users/1/sleep.json').with(query: { access_token: '1' })).to have_been_made
       end
     end
+    context 'paginated true' do
+      before do
+        stub_get("/organizations/1/sleep.json")
+          .with(query: { access_token: '1', paginated: "true" })
+          .to_return(body: fixture('sleeps.json'),
+        headers: { content_type: 'application/json; charset=utf-8' })
+      end
+      it 'returns a Validic Response' do
+        sleep_records = client.get_sleep(access_token: '1', paginated: "true")
+        expect(sleep_records).to be_a Validic::Response
+        expect(sleep_records.summary.limit).to eq 2_000
+      end
+    end
   end
 
   describe '#create_sleep' do

--- a/spec/validic/rest/tobacco_cessation_spec.rb
+++ b/spec/validic/rest/tobacco_cessation_spec.rb
@@ -37,6 +37,19 @@ describe Validic::REST::TobaccoCessation do
         expect(a_get('/organizations/1/users/1/tobacco_cessation.json').with(query: { access_token: '1' })).to have_been_made
       end
     end
+    context 'paginated true' do
+      before do
+        stub_get("/organizations/1/tobacco_cessation.json")
+          .with(query: { access_token: '1', paginated: "true" })
+          .to_return(body: fixture('tobacco_cessations.json'),
+        headers: { content_type: 'application/json; charset=utf-8' })
+      end
+      it 'returns a Validic Response' do
+        tobacco_cessation = client.get_tobacco_cessation(access_token: '1', paginated: "true")
+        expect(tobacco_cessation).to be_a Validic::Response
+        expect(tobacco_cessation.summary.limit).to eq 2_000
+      end
+    end
   end
 
   describe '#create_tobacco_cessation' do

--- a/spec/validic/rest/weight_spec.rb
+++ b/spec/validic/rest/weight_spec.rb
@@ -36,6 +36,19 @@ describe Validic::REST::Weight do
         expect(a_get('/organizations/1/users/1/weight.json').with(query: { access_token: '1' })).to have_been_made
       end
     end
+    context 'paginated true' do
+      before do
+        stub_get("/organizations/1/weight.json")
+          .with(query: { access_token: '1', paginated: "true" })
+          .to_return(body: fixture('weights.json'),
+        headers: { content_type: 'application/json; charset=utf-8' })
+      end
+      it 'returns a Validic Response' do
+        weights = client.get_weight(access_token: '1', paginated: "true")
+        expect(weights).to be_a Validic::Response
+        expect(weights.summary.limit).to eq 2_000
+      end
+    end
   end
 
   describe '#create_weight' do


### PR DESCRIPTION
Using paginated_request, this will return the first 2000 records of an endpoint.
Maximum of data returned is 2000.

limit paginated_request calls on this endpoints: 
  - biometrics, diabetes, fitness, nutrition, routine, sleep, tobacco_cessation, weight

using weightwatchers as my org
```
client.get_routine - ordinary call - 100 records
#<Benchmark::Tms:0x007fc4418a1b20 @label="", @real=2.434471, @cstime=0.0, @cutime=0.0, @stime=0.0, @utime=0.020000000000000018, @total=0.020000000000000018>
client.get_routine(paginated: "true") - paginated_request - 2000 records
#<Benchmark::Tms:0x007fc4420068e8 @label="", @real=9.464795, @cstime=0.0, @cutime=0.0, @stime=0.020000000000000018, @utime=0.13, @total=0.15000000000000002>
```