### PR TITLE
Set Client Organization API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    validic (0.4.1)
+    validic (0.4.3)
       faraday_middleware (~> 0.9.0)
       multi_json
 
@@ -13,12 +13,12 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
-    faraday (0.9.1)
+    faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.9.1)
+    faraday_middleware (0.9.2)
       faraday (>= 0.7.4, < 0.10)
     method_source (0.8.2)
-    multi_json (1.11.0)
+    multi_json (1.11.2)
     multipart-post (2.0.0)
     pry (0.10.1)
       coderay (~> 1.1.0)

--- a/README.md
+++ b/README.md
@@ -457,6 +457,13 @@ client.delete_tobacco_cessation(user_id: 'VALIDIC_USER_ID', _id: 'VALIDIC_ACTIVI
 client.create_fitness(user_id: 'VALIDIC_USER_ID', activity_id: 'UNIQUE_ACTIVITY_ID', extras: "{\"stars\": 3}")
 ```
 
+##### Overwrite Client Organization
+```ruby
+# This will assign a new user to the organization_id and access_token set as params
+client.provision_user(organization_id: 'ORGANIZATION_ID', access_token: 'ACCESS_TOKEN')
+# Can be use as well with other methods
+```
+
 ##   [Latest Records](https://validic.com/api/bulkdata/#latest)
 
 ###### You can also pass an options hash to filter latest results

--- a/lib/validic/client.rb
+++ b/lib/validic/client.rb
@@ -66,6 +66,16 @@ module Validic
 
     private
 
+    def overwrite_creds(options = {})
+      return self if options.is_a?(String) || options[:access_token].nil? || options[:organization_id].nil?
+      access_token = options.delete(:access_token) || Validic.access_token
+      organization_id = options.delete(:organization_id) || Validic.organization_id
+      return self if access_token == @access_token && organization_id == @organization_id
+      self.access_token = access_token
+      self.organization_id = organization_id
+      reload_config
+    end
+
     def default_headers
       {
         accept: 'application/json',

--- a/lib/validic/rest/apps.rb
+++ b/lib/validic/rest/apps.rb
@@ -5,12 +5,14 @@ module Validic
     module Apps
 
       def get_org_apps(params = {})
+        overwrite_creds(params)
         resp = get_request(:apps, params)
         build_response_attr(resp)
       end
       alias :get_apps :get_org_apps
 
       def get_user_synced_apps(options = {})
+        overwrite_creds(options)
         resp = get_request(:sync_apps,
                            authentication_token: options[:authentication_token])
         build_response_attr(resp)

--- a/lib/validic/rest/biometrics.rb
+++ b/lib/validic/rest/biometrics.rb
@@ -5,11 +5,13 @@ module Validic
     module Biometrics
 
       def get_biometrics(options = {})
+        overwrite_creds(options)
         resp = get_request(:biometrics, options)
         build_response_attr(resp)
       end
 
       def create_biometrics(options = {})
+        overwrite_creds(options)
         user_id = options.delete(:user_id)
         options = { user_id: user_id, biometrics: options }
         response = post_request(:biometrics, options)
@@ -17,6 +19,7 @@ module Validic
       end
 
       def update_biometrics(options = {})
+        overwrite_creds(options)
         user_id, _id = options.delete(:user_id), options.delete(:_id)
         options = { user_id: user_id, _id: _id, biometrics: options }
         response = put_request(:biometrics, options)
@@ -24,6 +27,7 @@ module Validic
       end
 
       def delete_biometrics(options = {})
+        overwrite_creds(options)
         user_id, _id = options.delete(:user_id), options.delete(:_id)
         options = { user_id: user_id, _id: _id }
         delete_request(:biometrics, options)
@@ -31,6 +35,7 @@ module Validic
       end
 
       def latest_biometrics(options = {})
+        overwrite_creds(options)
         resp = latest(:biometrics, options)
         build_response_attr(resp)
       end

--- a/lib/validic/rest/diabetes.rb
+++ b/lib/validic/rest/diabetes.rb
@@ -5,11 +5,13 @@ module Validic
     module Diabetes
 
       def get_diabetes(options = {})
+        overwrite_creds(options)
         resp = get_request(:diabetes, options)
         build_response_attr(resp)
       end
 
       def create_diabetes(options = {})
+        overwrite_creds(options)
         user_id = options.delete(:user_id)
         options = { user_id: user_id, diabetes: options }
         response = post_request(:diabetes, options)
@@ -17,6 +19,7 @@ module Validic
       end
 
       def update_diabetes(options = {})
+        overwrite_creds(options)
         user_id, _id = options.delete(:user_id), options.delete(:_id)
         options = { user_id: user_id, _id: _id, diabetes: options }
         response = put_request(:diabetes, options)
@@ -24,6 +27,7 @@ module Validic
       end
 
       def delete_diabetes(options = {})
+        overwrite_creds(options)
         user_id, _id = options.delete(:user_id), options.delete(:_id)
         options = { user_id: user_id, _id: _id }
         delete_request(:diabetes, options)
@@ -31,6 +35,7 @@ module Validic
       end
 
       def latest_diabetes(options = {})
+        overwrite_creds(options)
         resp = latest(:diabetes, options)
         build_response_attr(resp)
       end

--- a/lib/validic/rest/fitness.rb
+++ b/lib/validic/rest/fitness.rb
@@ -5,12 +5,14 @@ module Validic
     module Fitness
 
       def get_fitness(options = {})
+        overwrite_creds(options)
         resp = get_request(:fitness, options)
         build_response_attr(resp)
       end
       alias :get_fitnesses :get_fitness
 
       def create_fitness(options = {})
+        overwrite_creds(options)
         user_id = options.delete(:user_id)
         options = { user_id: user_id, fitness: options }
         response = post_request(:fitness, options)
@@ -18,6 +20,7 @@ module Validic
       end
 
       def update_fitness(options = {})
+        overwrite_creds(options)
         user_id, _id = options.delete(:user_id), options.delete(:_id)
         options = { user_id: user_id, _id: _id, fitness: options }
         response = put_request(:fitness, options)
@@ -25,6 +28,7 @@ module Validic
       end
 
       def delete_fitness(options = {})
+        overwrite_creds(options)
         user_id, _id = options.delete(:user_id), options.delete(:_id)
         options = { user_id: user_id, _id: _id }
         delete_request(:fitness, options)
@@ -32,6 +36,7 @@ module Validic
       end
 
       def latest_fitness(options = {})
+        overwrite_creds(options)
         resp = latest(:fitness, options)
         build_response_attr(resp)
       end

--- a/lib/validic/rest/nutrition.rb
+++ b/lib/validic/rest/nutrition.rb
@@ -5,12 +5,14 @@ module Validic
     module Nutrition
 
       def get_nutrition(options = {})
+        overwrite_creds(options)
         resp = get_request(:nutrition, options)
         build_response_attr(resp)
       end
       alias :get_nutritions :get_nutrition
 
       def create_nutrition(options = {})
+        overwrite_creds(options)
         user_id, _id = options.delete(:user_id), options.delete(:_id)
         options = { user_id: user_id, nutrition: options }
         response = post_request(:nutrition, options)
@@ -18,6 +20,7 @@ module Validic
       end
 
       def update_nutrition(options = {})
+        overwrite_creds(options)
         user_id, _id = options.delete(:user_id), options.delete(:_id)
         options = { user_id: user_id, _id: _id, nutrition: options }
         response = put_request(:nutrition, options)
@@ -25,6 +28,7 @@ module Validic
       end
 
       def delete_nutrition(options = {})
+        overwrite_creds(options)
         user_id, _id = options.delete(:user_id), options.delete(:_id)
         options = { user_id: user_id, _id: _id }
         delete_request(:nutrition, options)
@@ -32,6 +36,7 @@ module Validic
       end
 
       def latest_nutrition(options = {})
+        overwrite_creds(options)
         resp = latest(:nutrition, options)
         build_response_attr(resp)
       end

--- a/lib/validic/rest/organizations.rb
+++ b/lib/validic/rest/organizations.rb
@@ -4,6 +4,7 @@ module Validic
   module REST
     module Organizations
       def get_organization(params = {})
+        overwrite_creds(params)
         resp = get_request(:organizations, params)
         build_response_attr(resp)
       end

--- a/lib/validic/rest/profile.rb
+++ b/lib/validic/rest/profile.rb
@@ -4,11 +4,13 @@ module Validic
   module REST
     module Profile
       def get_profile(options = {})
+        overwrite_creds(options)
         resp = get_request(:profile, options)
         Validic::Profile.new(resp)
       end
 
       def create_profile(options = {})
+        overwrite_creds(options)
         token = options.delete(:authentication_token)
         resp = post_request(:profile, authentication_token: token, profile: options)
         Validic::Profile.new(resp['profile'])

--- a/lib/validic/rest/request.rb
+++ b/lib/validic/rest/request.rb
@@ -76,7 +76,8 @@ module Validic
       end
 
       def request(method, path, options)
-        options[:access_token] = options[:access_token].nil? ? Validic.access_token : options[:access_token]
+        options[:access_token] = options.fetch(:access_token, Validic.access_token)
+        options[:organization_id] = options.fetch(:organization_id, Validic.organization_id)
         response = connection.send(method) do |request|
           case method
           when :get

--- a/lib/validic/rest/routine.rb
+++ b/lib/validic/rest/routine.rb
@@ -5,12 +5,14 @@ module Validic
     module Routine
 
       def get_routine(params = {})
+        overwrite_creds(params)
         resp = get_request(:routine, params)
         build_response_attr(resp)
       end
       alias :get_routines :get_routine
 
       def create_routine(options = {})
+        overwrite_creds(options)
         user_id = options.delete(:user_id)
         options = { user_id: user_id, routine: options }
         response = post_request(:routine, options)
@@ -18,6 +20,7 @@ module Validic
       end
 
       def update_routine(options = {})
+        overwrite_creds(options)
         user_id, _id = options.delete(:user_id), options.delete(:_id)
         options = { user_id: user_id, _id: _id, routine: options }
         response = put_request(:routine, options)
@@ -25,6 +28,7 @@ module Validic
       end
 
       def delete_routine(options = {})
+        overwrite_creds(options)
         user_id, _id = options.delete(:user_id), options.delete(:_id)
         options = { user_id: user_id, _id: _id }
         delete_request(:routine, options)
@@ -32,6 +36,7 @@ module Validic
       end
 
       def latest_routine(options = {})
+        overwrite_creds(options)
         resp = latest(:routine, options)
         build_response_attr(resp)
       end

--- a/lib/validic/rest/sleep.rb
+++ b/lib/validic/rest/sleep.rb
@@ -5,12 +5,14 @@ module Validic
     module Sleep
 
       def get_sleep(options = {})
+        overwrite_creds(options)
         resp = get_request(:sleep, options)
         build_response_attr(resp)
       end
       alias :get_sleeps :get_sleep
 
       def create_sleep(options = {})
+        overwrite_creds(options)
         user_id = options.delete(:user_id)
         options = { user_id: user_id, sleep: options }
         response = post_request(:sleep, options)
@@ -18,6 +20,7 @@ module Validic
       end
 
       def update_sleep(options = {})
+        overwrite_creds(options)
         user_id, _id = options.delete(:user_id), options.delete(:_id)
         options = { user_id: user_id, _id: _id, sleep: options }
         response = put_request(:sleep, options)
@@ -25,11 +28,13 @@ module Validic
       end
 
       def latest_sleep(options = {})
+        overwrite_creds(options)
         resp = latest(:sleep, options)
         build_response_attr(resp)
       end
 
       def delete_sleep(options = {})
+        overwrite_creds(options)
         user_id, _id = options.delete(:user_id), options.delete(:_id)
         options = { user_id: user_id, _id: _id }
         delete_request(:sleep, options)

--- a/lib/validic/rest/tobacco_cessation.rb
+++ b/lib/validic/rest/tobacco_cessation.rb
@@ -5,12 +5,14 @@ module Validic
     module TobaccoCessation
 
       def get_tobacco_cessation(options = {})
+        overwrite_creds(options)
         resp = get_request(:tobacco_cessation, options)
         build_response_attr(resp)
       end
       alias :get_tobacco_cessations :get_tobacco_cessation
 
       def create_tobacco_cessation(options = {})
+        overwrite_creds(options)
         user_id = options.delete(:user_id)
         options = { user_id: user_id, tobacco_cessation: options }
         response = post_request(:tobacco_cessation, options)
@@ -18,6 +20,7 @@ module Validic
       end
 
       def update_tobacco_cessation(options = {})
+        overwrite_creds(options)
         user_id, _id = options.delete(:user_id), options.delete(:_id)
         options = { user_id: user_id, _id: _id, tobacco_cessation: options }
         response = put_request(:tobacco_cessation, options)
@@ -25,6 +28,7 @@ module Validic
       end
 
       def delete_tobacco_cessation(options = {})
+        overwrite_creds(options)
         user_id, _id = options.delete(:user_id), options.delete(:_id)
         options = { user_id: user_id, _id: _id }
         delete_request(:tobacco_cessation, options)
@@ -32,6 +36,7 @@ module Validic
       end
 
       def latest_tobacco_cessation(options = {})
+        overwrite_creds(options)
         resp = latest(:tobacco_cessation, options)
         build_response_attr(resp)
       end

--- a/lib/validic/rest/users.rb
+++ b/lib/validic/rest/users.rb
@@ -5,28 +5,33 @@ module Validic
     module Users
 
       def get_users(options = {})
+        overwrite_creds(options)
         resp = get_request(:users, options)
         build_response_attr(resp)
       end
       alias :get_user :get_users
 
       def refresh_token(options = {})
+        overwrite_creds(options)
         response = get_request(:refresh_token, options)
         Validic::User.new(response['user'])
       end
 
       def me(options = {})
+        overwrite_creds(options)
         response = get_request(:me, options)
         response['me']['_id']
       end
 
       def provision_user(options = {})
+        overwrite_creds(options)
         response = post_request(:users, { user: options })
         Validic::User.new(response['user'])
       end
       alias :user_provision :provision_user
 
       def update_user(options = {})
+        overwrite_creds(options)
         user_id = options.delete(:user_id)
         response = put_request(:users, { user_id: user_id, user: options })
         Validic::User.new(response['user'])
@@ -34,18 +39,21 @@ module Validic
       alias :user_update :update_user
 
       def delete_user(options = {})
+        overwrite_creds(options)
         delete_request(:users, { user_id: options[:user_id] })
         true
       end
       alias :user_delete :delete_user
 
       def suspend_user(options = {})
+        overwrite_creds(options)
         put_request(:users, { user_id: options[:user_id], suspend: '1' })
         true
       end
       alias :user_suspend :suspend_user
 
       def unsuspend_user(options = {})
+        overwrite_creds(options)
         put_request(:users, { user_id: options[:user_id], suspend: '0' })
         true
       end

--- a/lib/validic/rest/weight.rb
+++ b/lib/validic/rest/weight.rb
@@ -5,6 +5,7 @@ module Validic
     module Weight
 
       def get_weight(params={})
+        overwrite_creds(params)
         resp = get_request(:weight, params)
         build_response_attr(resp)
       end
@@ -12,6 +13,7 @@ module Validic
       alias :get_weights :get_weight
 
       def create_weight(options={})
+        overwrite_creds(options)
         user_id = options.delete(:user_id)
         options = { user_id: user_id, weight: options }
         resp = post_request(:weight, options)
@@ -20,6 +22,7 @@ module Validic
       end
 
       def update_weight(options={})
+        overwrite_creds(options)
         user_id, _id = options.delete(:user_id), options.delete(:_id)
         options = { user_id: user_id, _id: _id, weight: options }
         response = put_request(:weight, options)
@@ -27,6 +30,7 @@ module Validic
       end
 
       def delete_weight(options = {})
+        overwrite_creds(options)
         user_id, _id = options.delete(:user_id), options.delete(:_id)
         options = { user_id: user_id, _id: _id }
         delete_request(:weight, options)
@@ -34,6 +38,7 @@ module Validic
       end
 
       def latest_weight(options={})
+        overwrite_creds(options)
         resp = latest(:weight, options)
         build_response_attr(resp)
       end

--- a/lib/validic/version.rb
+++ b/lib/validic/version.rb
@@ -1,3 +1,3 @@
 module Validic
-  VERSION = '0.4.1'
+  VERSION = '0.4.3'
 end

--- a/spec/fixtures/user2.json
+++ b/spec/fixtures/user2.json
@@ -1,0 +1,8 @@
+{
+  "user": {
+    "_id": "2",
+    "uid": "123467890",
+    "access_token": "2",
+    "profile": null
+  }
+}

--- a/spec/validic/error_spec.rb
+++ b/spec/validic/error_spec.rb
@@ -7,7 +7,7 @@ describe Validic::Error do
     %w(weight nutrition biometrics diabetes tobacco_cessation routine fitness weight).each do |activity|
       before do
         stub_get("/organizations/1/users/0/#{activity}.json")
-          .with(query: { access_token: '1' })
+          .with(query: { access_token: '1', organization_id: '1' })
           .to_return(status: 404, body: fixture('not_found.json'), headers: {content_type: 'application/json; charset=utf-8'})
       end
       it 'raises a NotFound error' do
@@ -19,7 +19,7 @@ describe Validic::Error do
   context 'forbidden' do
     before do
       stub_get("/organizations/0.json")
-        .with(query: { access_token: '0' })
+        .with(query: { access_token: '0', organization_id: '0' })
         .to_return(status: 403, body: fixture('forbidden.json'), headers: {content_type: 'application/json; charset=utf-8'})
     end
     it 'raises a Forbidden error' do
@@ -30,7 +30,7 @@ describe Validic::Error do
   context 'unprocessable entity' do
     before do
       stub_post("/organizations/1/users/1/nutrition.json")
-        .with(body: { nutrition: {}, access_token: '1' })
+        .with(body: { nutrition: {}, access_token: '1', organization_id: '1' })
         .to_return(status: 422, body: fixture('unprocessable_entity.json'), headers: {content_type: 'application/json; charset=utf-8'})
     end
     it 'raises an UnprocessableEntity error' do
@@ -41,7 +41,7 @@ describe Validic::Error do
   context 'conflict' do
     before do
       stub_post("/organizations/1/users.json")
-        .with(body: { user: { uid: '123' }, access_token: '1'}.to_json)
+        .with(body: { user: { uid: '123' }, access_token: '1', organization_id: '1'}.to_json)
         .to_return(status: 409, body: fixture('conflict.json'), headers: {content_type: 'application/json; charset=utf-8'})
     end
     it 'raises a Conflict error' do
@@ -52,7 +52,7 @@ describe Validic::Error do
   context 'internal server error' do
     before do
       stub_post("/organizations/1/users.json")
-        .with(body: { user: '123', access_token: '1'}.to_json)
+        .with(body: { user: '123', access_token: '1', organization_id: '1'}.to_json)
         .to_return(status: 500, body: fixture('internal_server.json'), headers: {content_type: 'application/json; charset=utf-8'})
     end
     it 'raises a Conflict error' do
@@ -63,7 +63,7 @@ describe Validic::Error do
   context 'unauthorized' do
     before do
       stub_get("/profile.json")
-        .with(query: { access_token: '1' })
+        .with(query: { access_token: '1', organization_id: '1' })
         .to_return(status: 401, body: fixture('unauthorized.json'), headers: {content_type: 'application/json; charset=utf-8'})
     end
     it 'raises a Conflict error' do

--- a/spec/validic/expanded_spec.rb
+++ b/spec/validic/expanded_spec.rb
@@ -11,7 +11,8 @@ describe 'expanded for all objects' do
         #set up stub request for a create call with extras
         stub_post("/organizations/1/users/1/#{object}.json")
           .with(body: { object.to_sym => { timestamp: '2013-03-10T07:12:16+00:00',
-        activity_id: '12345', extras: "{\"stars\": 3}" }, access_token: '1' }.to_json)
+        activity_id: '12345', extras: "{\"stars\": 3}" }, access_token: '1',
+        organization_id: '1' }.to_json)
           .to_return(body: fixture("#{object}-extras.json"),
         headers: { content_type: 'application/json; charset=utf-8'} )
 
@@ -24,7 +25,7 @@ describe 'expanded for all objects' do
         expect(a_post("/organizations/1/users/1/#{object}.json")
           .with(body: { object.to_sym => { timestamp: '2013-03-10T07:12:16+00:00',
         activity_id: '12345', extras: "{\"stars\": 3}"},
-          access_token: '1' }.to_json)).to have_been_made
+          access_token: '1', organization_id: '1' }.to_json)).to have_been_made
       end
       it 'creates the correct object' do
         klass = Validic.const_get(camelize_response_key(object))
@@ -36,7 +37,7 @@ describe 'expanded for all objects' do
       before do
         stub_put("/organizations/1/users/1/#{object}/51552cddfded0807c4000096.json")
           .with(body: { object.to_sym => { timestamp: '2013-03-10T07:12:16+00:00',
-        extras: "{\"stars\": 3}"}, access_token: '1' }.to_json)
+        extras: "{\"stars\": 3}"}, access_token: '1', organization_id: '1' }.to_json)
           .to_return(body: fixture("#{object}-extras.json"),
         headers: { content_type: 'application/json; charset=utf-8'} )
           @obj = client.send("update_#{object}", user_id: '1', _id: "51552cddfded0807c4000096",
@@ -47,7 +48,7 @@ describe 'expanded for all objects' do
         expect(a_put("/organizations/1/users/1/#{object}/51552cddfded0807c4000096.json")
           .with(body: { object.to_sym => { timestamp: '2013-03-10T07:12:16+00:00',
         extras: "{\"stars\": 3}"},
-          access_token: '1' }.to_json)).to have_been_made
+          access_token: '1', organization_id: '1' }.to_json)).to have_been_made
       end
       it 'returns an object' do
         klass = Validic.const_get(camelize_response_key(object))
@@ -58,7 +59,7 @@ describe 'expanded for all objects' do
     context "#get #{object}" do
       before do
         stub_get("/organizations/1/#{object}.json")
-          .with(query: { access_token: '1', expanded: '1' })
+          .with(query: { access_token: '1', expanded: '1', organization_id: '1' })
           .to_return(body: fixture("#{object}-expanded.json"),
         headers: { content_type: 'application/json; charset=utf-8' })
 
@@ -69,7 +70,7 @@ describe 'expanded for all objects' do
       end
       it 'makes an object URI request with expanded' do
         expect(a_get("/organizations/1/#{object}.json")
-          .with(query: { access_token: '1', expanded: '1' }))
+          .with(query: { access_token: '1', expanded: '1', organization_id: '1' }))
           .to have_been_made
       end
     end
@@ -84,4 +85,3 @@ def camelize_response_key(str)
   key.chop! if %w(Users Apps).include?(key) #strip last letter off to match ::User or ::App
   key
 end
-

--- a/spec/validic/rest/apps_spec.rb
+++ b/spec/validic/rest/apps_spec.rb
@@ -7,7 +7,7 @@ describe Validic::REST::Apps do
     context 'non-expanded' do
       before do
         stub_get("/organizations/1/apps.json")
-          .with(query: { access_token: '1' })
+          .with(query: { access_token: '1', organization_id: '1' })
           .to_return(body: fixture('apps.json'),
         headers: { content_type: 'application/json; charset=utf-8' })
           @apps = client.get_org_apps
@@ -18,13 +18,13 @@ describe Validic::REST::Apps do
       end
       it 'makes an apps request to the correct url' do
         expect(a_get('/organizations/1/apps.json')
-          .with(query: { access_token: '1' })).to have_been_made
+          .with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
     context 'expanded' do
       before do
         stub_get("/organizations/1/apps.json")
-          .with(query: { access_token: '1', expanded: 1 })
+          .with(query: { access_token: '1', expanded: 1, organization_id: '1' })
           .to_return(body: fixture('apps.json'),
         headers: { content_type: 'application/json; charset=utf-8' })
           @apps = client.get_org_apps(expanded: 1)
@@ -34,7 +34,7 @@ describe Validic::REST::Apps do
       end
       it 'makes an apps request to the correct url' do
         expect(a_get('/organizations/1/apps.json')
-          .with(query: { access_token: '1', expanded: '1' })).to have_been_made
+          .with(query: { access_token: '1', expanded: '1', organization_id: '1' })).to have_been_made
       end
     end
   end
@@ -42,7 +42,7 @@ describe Validic::REST::Apps do
   describe '#get_user_synced_apps' do
     before do
       stub_get('/organizations/1/sync_apps.json')
-        .with(query: { authentication_token: '2', access_token: '1' })
+        .with(query: { authentication_token: '2', access_token: '1', organization_id: '1' })
         .to_return(body: fixture('synced_apps.json'),
       headers: { content_type: 'application/json; charset=utf-8' })
         @synced_apps = client.get_user_synced_apps(authentication_token: '2')
@@ -52,7 +52,7 @@ describe Validic::REST::Apps do
     end
     it 'makes a sync apps call to the correct url' do
       expect(a_get('/organizations/1/sync_apps.json')
-        .with(query: { authentication_token: '2', access_token: '1' }))
+        .with(query: { authentication_token: '2', access_token: '1', organization_id: '1' }))
         .to have_been_made
     end
   end

--- a/spec/validic/rest/biometrics_spec.rb
+++ b/spec/validic/rest/biometrics_spec.rb
@@ -8,7 +8,7 @@ describe Validic::REST::Biometrics do
     context 'no user_id given' do
       before do
         stub_get("/organizations/1/biometrics.json")
-          .with(query: { access_token: '1' })
+          .with(query: { access_token: '1', organization_id: '1' })
           .to_return(body: fixture('biometrics_records.json'),
         headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -18,13 +18,13 @@ describe Validic::REST::Biometrics do
       end
       it 'makes a biometrics request to the correct url' do
         client.get_biometrics
-        expect(a_get('/organizations/1/biometrics.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/biometrics.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
     context 'with user_id' do
       before do
         stub_get("/organizations/1/users/1/biometrics.json")
-          .with(query: { access_token: '1' })
+          .with(query: { access_token: '1', organization_id: '1' })
           .to_return(body: fixture('bulk_biometrics_records.json'),
         headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -34,7 +34,7 @@ describe Validic::REST::Biometrics do
       end
       it 'makes a biometrics request to the correct url' do
         client.get_biometrics(user_id: '1')
-        expect(a_get('/organizations/1/users/1/biometrics.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/users/1/biometrics.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
   end
@@ -43,7 +43,8 @@ describe Validic::REST::Biometrics do
     before do
       stub_post("/organizations/1/users/1/biometrics.json")
         .with(body: { biometrics: { timestamp: '2013-03-10T07:12:16+00:00', activity_id: '12345' },
-                      access_token: '1' }.to_json)
+                      access_token: '1',
+                      organization_id: '1' }.to_json)
         .to_return(body: fixture('biometrics_record.json'),
           headers: { content_type: 'application/json; charset=utf-8'} )
     end
@@ -51,8 +52,9 @@ describe Validic::REST::Biometrics do
       client.create_biometrics(user_id: '1', timestamp: '2013-03-10T07:12:16+00:00', activity_id: '12345')
       expect(a_post('/organizations/1/users/1/biometrics.json')
         .with(body: { biometrics: { timestamp: '2013-03-10T07:12:16+00:00',
-                                  activity_id: '12345' },
-                      access_token: '1' }.to_json)).to have_been_made
+                                    activity_id: '12345' },
+                      access_token: '1',
+                      organization_id: '1' }.to_json)).to have_been_made
     end
     it 'returns a Biometrics' do
       biometrics_record = client.create_biometrics(user_id: '1', timestamp: '2013-03-10T07:12:16+00:00', activity_id: '12345')
@@ -65,7 +67,8 @@ describe Validic::REST::Biometrics do
     before do
       stub_put("/organizations/1/users/1/biometrics/51552cddfded0807c4000096.json")
         .with(body: { biometrics: { timestamp: '2013-03-10T07:12:16+00:00' },
-                                   access_token: '1' }.to_json)
+                      access_token: '1',
+                      organization_id: '1' }.to_json)
         .to_return(body: fixture('biometrics_record.json'),
                    headers: {content_type: 'application/json; charset=utf-8'})
     end
@@ -73,7 +76,8 @@ describe Validic::REST::Biometrics do
       client.update_biometrics(user_id: '1', _id: '51552cddfded0807c4000096', timestamp: '2013-03-10T07:12:16+00:00')
       expect(a_put('/organizations/1/users/1/biometrics/51552cddfded0807c4000096.json')
         .with(body: { biometrics: { timestamp: '2013-03-10T07:12:16+00:00' },
-                      access_token: '1' }.to_json)).to have_been_made
+                      access_token: '1',
+                      organization_id: '1' }.to_json)).to have_been_made
     end
     it 'returns a Biometrics' do
       biometrics_record = client.update_biometrics(user_id: '1', _id: '51552cddfded0807c4000096', timestamp: '2013-03-10T07:12:16+00:00')
@@ -98,7 +102,7 @@ describe Validic::REST::Biometrics do
     context 'with user_id' do
       before do
         stub_get("/organizations/1/users/2/biometrics/latest.json").
-          with(query: { access_token: '1' }).
+          with(query: { access_token: '1', organization_id: '1' }).
           to_return(body: fixture('biometrics_records.json'),
                     headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -108,13 +112,13 @@ describe Validic::REST::Biometrics do
       end
       it 'builds a latest url' do
         client.latest_biometrics(user_id: '2')
-        expect(a_get('/organizations/1/users/2/biometrics/latest.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/users/2/biometrics/latest.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
     context 'without user_id' do
       before do
         stub_get("/organizations/1/biometrics/latest.json").
-          with(query: { access_token: '1' }).
+          with(query: { access_token: '1', organization_id: '1' }).
           to_return(body: fixture('biometrics_records.json'),
                     headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -124,7 +128,7 @@ describe Validic::REST::Biometrics do
       end
       it 'builds a latest url' do
         client.latest_biometrics
-        expect(a_get('/organizations/1/biometrics/latest.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/biometrics/latest.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
   end

--- a/spec/validic/rest/diabetes_spec.rb
+++ b/spec/validic/rest/diabetes_spec.rb
@@ -8,7 +8,7 @@ describe Validic::REST::Diabetes do
     context 'no user_id given' do
       before do
         stub_get("/organizations/1/diabetes.json")
-          .with(query: { access_token: '1' })
+          .with(query: { access_token: '1', organization_id: '1' })
           .to_return(body: fixture('diabetes_records.json'),
         headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -18,13 +18,13 @@ describe Validic::REST::Diabetes do
       end
       it 'makes a diabetes request to the correct url' do
         client.get_diabetes
-        expect(a_get('/organizations/1/diabetes.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/diabetes.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
     context 'with user_id' do
       before do
         stub_get("/organizations/1/users/1/diabetes.json")
-          .with(query: { access_token: '1' })
+          .with(query: { access_token: '1', organization_id: '1' })
           .to_return(body: fixture('bulk_diabetes_records.json'),
         headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -34,7 +34,7 @@ describe Validic::REST::Diabetes do
       end
       it 'makes a diabetes request to the correct url' do
         client.get_diabetes(user_id: '1')
-        expect(a_get('/organizations/1/users/1/diabetes.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/users/1/diabetes.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
   end
@@ -43,7 +43,8 @@ describe Validic::REST::Diabetes do
     before do
       stub_post("/organizations/1/users/1/diabetes.json")
         .with(body: { diabetes: { timestamp: '2013-03-10T07:12:16+00:00', activity_id: '12345' },
-                      access_token: '1' }.to_json)
+                      access_token: '1',
+                      organization_id: '1' }.to_json)
         .to_return(body: fixture('diabetes_record.json'),
           headers: { content_type: 'application/json; charset=utf-8'} )
     end
@@ -52,7 +53,8 @@ describe Validic::REST::Diabetes do
       expect(a_post('/organizations/1/users/1/diabetes.json')
         .with(body: { diabetes: { timestamp: '2013-03-10T07:12:16+00:00',
                                   activity_id: '12345' },
-                      access_token: '1' }.to_json)).to have_been_made
+                      access_token: '1',
+                      organization_id: '1' }.to_json)).to have_been_made
     end
     it 'returns a Diabetes' do
       diabetes_record = client.create_diabetes(user_id: '1', timestamp: '2013-03-10T07:12:16+00:00', activity_id: '12345')
@@ -65,7 +67,8 @@ describe Validic::REST::Diabetes do
     before do
       stub_put("/organizations/1/users/1/diabetes/51552cddfded0807c4000096.json")
         .with(body: { diabetes: { timestamp: '2013-03-10T07:12:16+00:00' },
-                                   access_token: '1' }.to_json)
+                      access_token: '1',
+                      organization_id: '1' }.to_json)
         .to_return(body: fixture('diabetes_record.json'),
                    headers: {content_type: 'application/json; charset=utf-8'})
     end
@@ -73,7 +76,8 @@ describe Validic::REST::Diabetes do
       client.update_diabetes(user_id: '1', _id: '51552cddfded0807c4000096', timestamp: '2013-03-10T07:12:16+00:00')
       expect(a_put('/organizations/1/users/1/diabetes/51552cddfded0807c4000096.json')
         .with(body: { diabetes: { timestamp: '2013-03-10T07:12:16+00:00' },
-                      access_token: '1' }.to_json)).to have_been_made
+                      access_token: '1',
+                      organization_id: '1' }.to_json)).to have_been_made
     end
     it 'returns a Diabetes' do
       diabetes_record = client.update_diabetes(user_id: '1', _id: '51552cddfded0807c4000096', timestamp: '2013-03-10T07:12:16+00:00')
@@ -98,7 +102,7 @@ describe Validic::REST::Diabetes do
     context 'with user_id' do
       before do
         stub_get("/organizations/1/users/2/diabetes/latest.json").
-          with(query: { access_token: '1' }).
+          with(query: { access_token: '1',organization_id: '1' }).
           to_return(body: fixture('diabetes_records.json'),
                     headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -108,13 +112,13 @@ describe Validic::REST::Diabetes do
       end
       it 'builds a latest url' do
         client.latest_diabetes(user_id: '2')
-        expect(a_get('/organizations/1/users/2/diabetes/latest.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/users/2/diabetes/latest.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
     context 'without user_id' do
       before do
         stub_get("/organizations/1/diabetes/latest.json").
-          with(query: { access_token: '1' }).
+          with(query: { access_token: '1', organization_id: '1' }).
           to_return(body: fixture('diabetes_records.json'),
                     headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -124,7 +128,7 @@ describe Validic::REST::Diabetes do
       end
       it 'builds a latest url' do
         client.latest_diabetes
-        expect(a_get('/organizations/1/diabetes/latest.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/diabetes/latest.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
   end

--- a/spec/validic/rest/fitness_spec.rb
+++ b/spec/validic/rest/fitness_spec.rb
@@ -8,7 +8,7 @@ describe Validic::REST::Fitness do
     context 'no user_id given' do
       before do
         stub_get("/organizations/1/fitness.json")
-          .with(query: { access_token: '1' })
+          .with(query: { access_token: '1', organization_id: '1' })
           .to_return(body: fixture('fitnesses.json'),
         headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -18,13 +18,13 @@ describe Validic::REST::Fitness do
       end
       it 'makes a fitness request to the correct url' do
         client.get_fitness
-        expect(a_get('/organizations/1/fitness.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/fitness.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
     context 'with user_id' do
       before do
         stub_get("/organizations/1/users/1/fitness.json")
-          .with(query: { access_token: '1' })
+          .with(query: { access_token: '1', organization_id: '1' })
           .to_return(body: fixture('bulk_fitnesses.json'),
         headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -34,7 +34,7 @@ describe Validic::REST::Fitness do
       end
       it 'makes a fitness request to the correct url' do
         client.get_fitness(user_id: '1')
-        expect(a_get('/organizations/1/users/1/fitness.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/users/1/fitness.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
   end
@@ -43,7 +43,7 @@ describe Validic::REST::Fitness do
     before do
       stub_post("/organizations/1/users/1/fitness.json")
         .with(body: { fitness: { timestamp: '2013-03-10T07:12:16+00:00', activity_id: '12345' },
-                      access_token: '1' }.to_json)
+                      access_token: '1', organization_id: '1' }.to_json)
         .to_return(body: fixture('fitness.json'),
           headers: { content_type: 'application/json; charset=utf-8'} )
     end
@@ -51,8 +51,9 @@ describe Validic::REST::Fitness do
       client.create_fitness(user_id: '1', timestamp: '2013-03-10T07:12:16+00:00', activity_id: '12345')
       expect(a_post('/organizations/1/users/1/fitness.json')
         .with(body: { fitness: { timestamp: '2013-03-10T07:12:16+00:00',
-                                   activity_id: '12345' },
-                      access_token: '1' }.to_json)).to have_been_made
+                                 activity_id: '12345' },
+                                 access_token: '1',
+                                 organization_id: '1' }.to_json)).to have_been_made
     end
     it 'returns a Fitness' do
       fitness = client.create_fitness(user_id: '1', timestamp: '2013-03-10T07:12:16+00:00', activity_id: '12345')
@@ -65,7 +66,8 @@ describe Validic::REST::Fitness do
     before do
       stub_put("/organizations/1/users/1/fitness/51552cddfded0807c4000096.json")
         .with(body: { fitness: { timestamp: '2013-03-10T07:12:16+00:00' },
-                                   access_token: '1' }.to_json)
+                      access_token: '1',
+                      organization_id: '1' }.to_json)
         .to_return(body: fixture('fitness.json'),
                    headers: {content_type: 'application/json; charset=utf-8'})
     end
@@ -73,7 +75,8 @@ describe Validic::REST::Fitness do
       client.update_fitness(user_id: '1', _id: '51552cddfded0807c4000096', timestamp: '2013-03-10T07:12:16+00:00')
       expect(a_put('/organizations/1/users/1/fitness/51552cddfded0807c4000096.json')
         .with(body: { fitness: { timestamp: '2013-03-10T07:12:16+00:00' },
-                      access_token: '1' }.to_json)).to have_been_made
+                      access_token: '1',
+                      organization_id: '1' }.to_json)).to have_been_made
     end
     it 'returns a Fitness' do
       fitness = client.update_fitness(user_id: '1', _id: '51552cddfded0807c4000096', timestamp: '2013-03-10T07:12:16+00:00')
@@ -98,7 +101,7 @@ describe Validic::REST::Fitness do
     context 'with user_id' do
       before do
         stub_get("/organizations/1/users/2/fitness/latest.json").
-          with(query: { access_token: '1' }).
+          with(query: { access_token: '1', organization_id: '1' }).
           to_return(body: fixture('fitnesses.json'),
                     headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -108,13 +111,13 @@ describe Validic::REST::Fitness do
       end
       it 'builds a latest url' do
         client.latest_fitness(user_id: '2')
-        expect(a_get('/organizations/1/users/2/fitness/latest.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/users/2/fitness/latest.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
     context 'without user_id' do
       before do
         stub_get("/organizations/1/fitness/latest.json").
-          with(query: { access_token: '1' }).
+          with(query: { access_token: '1', organization_id: '1' }).
           to_return(body: fixture('fitnesses.json'),
                     headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -124,7 +127,7 @@ describe Validic::REST::Fitness do
       end
       it 'builds a latest url' do
         client.latest_fitness
-        expect(a_get('/organizations/1/fitness/latest.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/fitness/latest.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
   end

--- a/spec/validic/rest/nutrition_spec.rb
+++ b/spec/validic/rest/nutrition_spec.rb
@@ -8,7 +8,7 @@ describe Validic::REST::Nutrition do
     context 'no user_id given' do
       before do
         stub_get("/organizations/1/nutrition.json")
-          .with(query: { access_token: '1' })
+          .with(query: { access_token: '1', organization_id: '1' })
           .to_return(body: fixture('nutritions.json'),
         headers: { content_type: 'application/json; charset=utf-8' })
           @nutrition = client.get_nutrition
@@ -18,14 +18,14 @@ describe Validic::REST::Nutrition do
       end
       it 'makes a nutrition request to the correct url' do
         expect(a_get('/organizations/1/nutrition.json')
-          .with(query: { access_token: '1' }))
+          .with(query: { access_token: '1', organization_id: '1' }))
           .to have_been_made
       end
     end
     context 'with user_id' do
       before do
         stub_get("/organizations/1/users/1/nutrition.json")
-          .with(query: { access_token: '1' })
+          .with(query: { access_token: '1', organization_id: '1' })
           .to_return(body: fixture('bulk_nutritions.json'),
         headers: { content_type: 'application/json; charset=utf-8' })
 
@@ -36,7 +36,7 @@ describe Validic::REST::Nutrition do
       end
       it 'makes a nutrition request to the correct url' do
         expect(a_get('/organizations/1/users/1/nutrition.json')
-          .with(query: { access_token: '1' }))
+          .with(query: { access_token: '1', organization_id: '1' }))
           .to have_been_made
       end
     end
@@ -47,7 +47,9 @@ describe Validic::REST::Nutrition do
       before do
         stub_post("/organizations/1/users/1/nutrition.json")
           .with(body: { nutrition: { timestamp: '2013-03-10T07:12:16+00:00',
-        activity_id: '12345' }, access_token: '1' }.to_json)
+                                     activity_id: '12345' },
+                        access_token: '1',
+                        organization_id: '1'}.to_json)
           .to_return(body: fixture('nutrition.json'),
         headers: { content_type: 'application/json; charset=utf-8'} )
       end
@@ -57,7 +59,7 @@ describe Validic::REST::Nutrition do
         expect(a_post('/organizations/1/users/1/nutrition.json')
           .with(body: { nutrition: { timestamp: '2013-03-10T07:12:16+00:00',
         activity_id: '12345' },
-        access_token: '1' }.to_json)).to have_been_made
+        access_token: '1', organization_id: '1' }.to_json)).to have_been_made
       end
       it 'returns a Nutrition' do
         nutrition = client.create_nutrition(user_id: '1', timestamp: '2013-03-10T07:12:16+00:00',
@@ -73,7 +75,8 @@ describe Validic::REST::Nutrition do
       before do
         stub_put("/organizations/1/users/1/nutrition/51552cddfded0807c4000096.json")
           .with(body: { nutrition: { timestamp: '2013-03-10T07:12:16+00:00' },
-        access_token: '1' }.to_json)
+                access_token: '1',
+                organization_id: '1' }.to_json)
           .to_return(body: fixture('nutrition.json'),
         headers: {content_type: 'application/json; charset=utf-8'})
       end
@@ -82,7 +85,8 @@ describe Validic::REST::Nutrition do
                                 timestamp: '2013-03-10T07:12:16+00:00')
         expect(a_put('/organizations/1/users/1/nutrition/51552cddfded0807c4000096.json')
           .with(body: { nutrition: { timestamp: '2013-03-10T07:12:16+00:00' },
-        access_token: '1' }.to_json)).to have_been_made
+                access_token: '1',
+                organization_id: '1' }.to_json)).to have_been_made
       end
       it 'returns a Nutrition' do
         nutrition = client.update_nutrition(user_id: '1', _id: '51552cddfded0807c4000096',
@@ -109,7 +113,7 @@ describe Validic::REST::Nutrition do
     context 'with user_id' do
       before do
         stub_get("/organizations/1/users/2/nutrition/latest.json").
-          with(query: { access_token: '1' }).
+          with(query: { access_token: '1', organization_id: '1' }).
           to_return(body: fixture('nutritions.json'),
                     headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -120,13 +124,13 @@ describe Validic::REST::Nutrition do
       it 'builds a latest url' do
         client.latest_nutrition(user_id: '2')
         expect(a_get('/organizations/1/users/2/nutrition/latest.json')
-          .with(query: { access_token: '1' })).to have_been_made
+          .with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
     context 'without user_id' do
       before do
         stub_get("/organizations/1/nutrition/latest.json").
-          with(query: { access_token: '1' }).
+          with(query: { access_token: '1', organization_id: '1' }).
           to_return(body: fixture('nutritions.json'),
                     headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -137,7 +141,7 @@ describe Validic::REST::Nutrition do
       it 'builds a latest url' do
         client.latest_nutrition
         expect(a_get('/organizations/1/nutrition/latest.json')
-          .with(query: { access_token: '1' })).to have_been_made
+          .with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
   end

--- a/spec/validic/rest/organizations_spec.rb
+++ b/spec/validic/rest/organizations_spec.rb
@@ -6,7 +6,7 @@ describe Validic::REST::Organizations do
   describe "#get_organization" do
     before do
       stub_get('/organizations/1.json')
-        .with(query: { access_token: '1' })
+        .with(query: { access_token: '1', organization_id: '1' })
         .to_return(body: fixture('organizations.json'),
       headers: { content_type: 'application/json; charset=utf-8' })
       @org = client.get_organization
@@ -16,7 +16,7 @@ describe Validic::REST::Organizations do
     end
     it 'creates the correct url' do
       expect(a_get('/organizations/1.json')
-        .with(query: { access_token: '1' }))
+        .with(query: { access_token: '1', organization_id: '1' }))
         .to have_been_made
     end
   end

--- a/spec/validic/rest/profile_spec.rb
+++ b/spec/validic/rest/profile_spec.rb
@@ -6,7 +6,7 @@ describe Validic::REST::Profile do
   describe '#get_profile' do
     before do
       stub_get("/profile.json")
-        .with(query: { access_token: '1', authentication_token: '2' })
+        .with(query: { access_token: '1', authentication_token: '2', organization_id: '1' })
         .to_return(body: fixture('profile.json'),
       headers: { content_type: 'application/json; charset=utf-8' })
 
@@ -17,7 +17,7 @@ describe Validic::REST::Profile do
     end
     it 'builds the correct path for profile' do
       expect(a_get('/profile.json')
-        .with(query: { access_token: '1', authentication_token: '2' }))
+        .with(query: { access_token: '1', authentication_token: '2', organization_id: '1' }))
         .to have_been_made
     end
   end
@@ -26,7 +26,10 @@ describe Validic::REST::Profile do
     before do
       stub_post("/profile.json")
         .with(
-      body: { authentication_token: '2', profile: { gender: "m", location: "NC" }, access_token: '1'}.to_json)
+      body: { authentication_token: '2',
+              profile: { gender: "m", location: "NC" },
+              access_token: '1',
+              organization_id: '1'}.to_json)
         .to_return(body: fixture('profile.json'),
       headers: { content_type: 'application/json; charset=utf-8' })
         @profile = client.create_profile(authentication_token: '2', gender: 'm', location: 'NC')
@@ -37,7 +40,10 @@ describe Validic::REST::Profile do
     it 'builds the correct path for profile' do
       expect(a_post('/profile.json')
         .with(body: { authentication_token: '2',
-      profile: { gender: "m", location: "NC" }, access_token: '1'}
+                      profile: { gender: "m", location: "NC" },
+                      access_token: '1',
+                      organization_id: '1'
+                    }
         .to_json)).to have_been_made
     end
   end

--- a/spec/validic/rest/routine_spec.rb
+++ b/spec/validic/rest/routine_spec.rb
@@ -7,7 +7,7 @@ describe Validic::REST::Routine do
     context 'no user_id given' do
       before do
         stub_get('/organizations/1/routine.json')
-          .with(query: { access_token: '1' })
+          .with(query: { access_token: '1', organization_id: '1' })
           .to_return(body: fixture('routines.json'),
         headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -17,13 +17,13 @@ describe Validic::REST::Routine do
       end
       it 'makes a routine request to the correct url' do
         client.get_routine
-        expect(a_get('/organizations/1/routine.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/routine.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
     context 'with user_id' do
       before do
         stub_get('/organizations/1/users/1/routine.json')
-          .with(query: { access_token: '1' })
+          .with(query: { access_token: '1', organization_id: '1' })
           .to_return(body: fixture('routines.json'), headers: { content_type: 'application/json; charset=utf-8' })
       end
       it 'returns a Response' do
@@ -32,7 +32,41 @@ describe Validic::REST::Routine do
       end
       it 'makes a routine request to the correct url' do
         client.get_routine(user_id: '1')
-        expect(a_get('/organizations/1/users/1/routine.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/users/1/routine.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
+      end
+    end
+  end
+
+  describe "#get_routine with another organization parameter" do
+    context 'no user_id given' do
+      before do
+        stub_get('/organizations/2/routine.json')
+          .with(query: { access_token: '2', organization_id: '2' })
+          .to_return(body: fixture('routines.json'),
+        headers: { content_type: 'application/json; charset=utf-8' })
+      end
+      it 'returns a validic response object' do
+        routine = client.get_routine(access_token: '2', organization_id: '2')
+        expect(routine).to be_a Validic::Response
+      end
+      it 'makes a routine request to the correct url' do
+        client.get_routine(access_token: '2', organization_id: '2')
+        expect(a_get('/organizations/2/routine.json').with(query: { access_token: '2', organization_id: '2' })).to have_been_made
+      end
+    end
+    context 'with user_id' do
+      before do
+        stub_get('/organizations/2/users/1/routine.json')
+          .with(query: { access_token: '2', organization_id: '2' })
+          .to_return(body: fixture('routines.json'), headers: { content_type: 'application/json; charset=utf-8' })
+      end
+      it 'returns a Response' do
+        routine = client.get_routine(user_id: '1', access_token: '2', organization_id: '2')
+        expect(routine).to be_a Validic::Response
+      end
+      it 'makes a routine request to the correct url' do
+        client.get_routine(user_id: '1',access_token: '2', organization_id: '2')
+        expect(a_get('/organizations/2/users/1/routine.json').with(query: { access_token: '2', organization_id: '2' })).to have_been_made
       end
     end
   end
@@ -41,7 +75,7 @@ describe Validic::REST::Routine do
     before do
       stub_post("/organizations/1/users/1/routine.json")
         .with(body: { routine: { timestamp: '2013-03-10T07:12:16+00:00', activity_id: '12345' },
-                      access_token: '1' }.to_json)
+                      access_token: '1', organization_id: '1' }.to_json)
         .to_return(body: fixture('routine.json'),
           headers: { content_type: 'application/json; charset=utf-8'} )
     end
@@ -49,8 +83,9 @@ describe Validic::REST::Routine do
       client.create_routine(user_id: '1', timestamp: '2013-03-10T07:12:16+00:00', activity_id: '12345')
       expect(a_post('/organizations/1/users/1/routine.json')
         .with(body: { routine: { timestamp: '2013-03-10T07:12:16+00:00',
-                                   activity_id: '12345' },
-                      access_token: '1' }.to_json)).to have_been_made
+                                 activity_id: '12345' },
+                                 access_token: '1',
+                                 organization_id: '1' }.to_json)).to have_been_made
     end
     it 'returns a routine' do
       routine = client.create_routine(user_id: '1', timestamp: '2013-03-10T07:12:16+00:00', activity_id: '12345')
@@ -63,7 +98,8 @@ describe Validic::REST::Routine do
     before do
       stub_put("/organizations/1/users/1/routine/51552cddfded0807c4000096.json")
         .with(body: { routine: { timestamp: '2013-03-10T07:12:16+00:00' },
-                                   access_token: '1' }.to_json)
+                      access_token: '1',
+                      organization_id: '1' }.to_json)
         .to_return(body: fixture('routine.json'),
                    headers: {content_type: 'application/json; charset=utf-8'})
     end
@@ -71,7 +107,8 @@ describe Validic::REST::Routine do
       client.update_routine(user_id: '1', _id: '51552cddfded0807c4000096', timestamp: '2013-03-10T07:12:16+00:00')
       expect(a_put('/organizations/1/users/1/routine/51552cddfded0807c4000096.json')
         .with(body: { routine: { timestamp: '2013-03-10T07:12:16+00:00' },
-                      access_token: '1' }.to_json)).to have_been_made
+                      access_token: '1',
+                      organization_id: '1' }.to_json)).to have_been_made
     end
     it 'returns a routine' do
       routine = client.update_routine(user_id: '1', _id: '51552cddfded0807c4000096', timestamp: '2013-03-10T07:12:16+00:00')
@@ -96,7 +133,7 @@ describe Validic::REST::Routine do
     context 'with user_id' do
       before do
         stub_get("/organizations/1/users/2/routine/latest.json").
-          with(query: { access_token: '1' }).
+          with(query: { access_token: '1', organization_id: '1' }).
           to_return(body: fixture('routines.json'),
                     headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -106,13 +143,13 @@ describe Validic::REST::Routine do
       end
       it 'builds a latest url' do
         client.latest_routine(user_id: '2')
-        expect(a_get('/organizations/1/users/2/routine/latest.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/users/2/routine/latest.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
     context 'without user_id' do
       before do
         stub_get("/organizations/1/routine/latest.json").
-          with(query: { access_token: '1' }).
+          with(query: { access_token: '1', organization_id: '1' }).
           to_return(body: fixture('routines.json'),
                     headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -122,7 +159,7 @@ describe Validic::REST::Routine do
       end
       it 'builds a latest url' do
         client.latest_routine
-        expect(a_get('/organizations/1/routine/latest.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/routine/latest.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
   end

--- a/spec/validic/rest/sleep_spec.rb
+++ b/spec/validic/rest/sleep_spec.rb
@@ -7,7 +7,7 @@ describe Validic::REST::Sleep do
     context 'no user_id given' do
       before do
         stub_get("/organizations/1/sleep.json")
-          .with(query: { access_token: '1' })
+          .with(query: { access_token: '1', organization_id: '1' })
           .to_return(body: fixture('sleeps.json'),
         headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -17,13 +17,13 @@ describe Validic::REST::Sleep do
       end
       it 'makes a sleep request to the correct url' do
         client.get_sleep
-        expect(a_get('/organizations/1/sleep.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/sleep.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
     context 'with user_id' do
       before do
         stub_get("/organizations/1/users/1/sleep.json")
-          .with(query: { access_token: '1' })
+          .with(query: { access_token: '1', organization_id: '1' })
           .to_return(body: fixture('bulk_sleeps.json'),
         headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -33,7 +33,7 @@ describe Validic::REST::Sleep do
       end
       it 'makes a sleep request to the correct url' do
         client.get_sleep(user_id: '1')
-        expect(a_get('/organizations/1/users/1/sleep.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/users/1/sleep.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
   end
@@ -45,7 +45,7 @@ describe Validic::REST::Sleep do
                               utc_offset: '+00:00', total_sleep: 477,
                               awake: 34, deep: 234, light: 94, rem: 115,
                               times_woken: 4, activity_id: '12345' },
-                              access_token: '1' }.to_json).
+                              access_token: '1', organization_id: '1' }.to_json).
                               to_return(body: fixture('sleep.json'),
                                         headers: { content_type: 'application/json; charset=utf-8'} )
     end
@@ -72,7 +72,8 @@ describe Validic::REST::Sleep do
                               utc_offset: '+00:00', total_sleep: 477,
                               awake: 224, deep: 234, light: 94, rem: 115,
                               times_woken: 4 },
-                              access_token: '1' }.to_json).
+                              access_token: '1',
+                              organization_id: '1' }.to_json).
                               to_return(body: fixture('sleep.json'),
                                         headers: {content_type: 'application/json; charset=utf-8'})
 
@@ -116,7 +117,7 @@ describe Validic::REST::Sleep do
     context 'with user_id' do
       before do
         stub_get("/organizations/1/users/2/sleep/latest.json").
-          with(query: { access_token: '1' }).
+          with(query: { access_token: '1', organization_id: '1' }).
           to_return(body: fixture('sleeps.json'),
                     headers: { content_type: 'application/json; charset=utf-8' })
           @latest = client.latest_sleep(user_id: '2')
@@ -125,13 +126,13 @@ describe Validic::REST::Sleep do
         expect(@latest).to be_a Validic::Response
       end
       it 'builds a latest url' do
-        expect(a_get('/organizations/1/users/2/sleep/latest.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/users/2/sleep/latest.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
     context 'without user_id' do
       before do
         stub_get("/organizations/1/sleep/latest.json").
-          with(query: { access_token: '1' }).
+          with(query: { access_token: '1', organization_id: '1' }).
           to_return(body: fixture('sleeps.json'),
                     headers: { content_type: 'application/json; charset=utf-8' })
           @latest = client.latest_sleep
@@ -140,7 +141,7 @@ describe Validic::REST::Sleep do
         expect(@latest).to be_a Validic::Response
       end
       it 'builds a latest url' do
-        expect(a_get('/organizations/1/sleep/latest.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/sleep/latest.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
   end

--- a/spec/validic/rest/tobacco_cessation_spec.rb
+++ b/spec/validic/rest/tobacco_cessation_spec.rb
@@ -8,7 +8,7 @@ describe Validic::REST::TobaccoCessation do
     context 'no user_id given' do
       before do
         stub_get("/organizations/1/tobacco_cessation.json")
-          .with(query: { access_token: '1' })
+          .with(query: { access_token: '1', organization_id: '1' })
           .to_return(body: fixture('tobacco_cessations.json'),
         headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -18,13 +18,13 @@ describe Validic::REST::TobaccoCessation do
       end
       it 'makes a tobacco_cessation request to the correct url' do
         client.get_tobacco_cessation
-        expect(a_get('/organizations/1/tobacco_cessation.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/tobacco_cessation.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
     context 'with user_id' do
       before do
         stub_get("/organizations/1/users/1/tobacco_cessation.json")
-          .with(query: { access_token: '1' })
+          .with(query: { access_token: '1', organization_id: '1' })
           .to_return(body: fixture('bulk_tobacco_cessations.json'),
         headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -34,7 +34,7 @@ describe Validic::REST::TobaccoCessation do
       end
       it 'makes a tobacco_cessation request to the correct url' do
         client.get_tobacco_cessation(user_id: '1')
-        expect(a_get('/organizations/1/users/1/tobacco_cessation.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/users/1/tobacco_cessation.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
   end
@@ -43,7 +43,7 @@ describe Validic::REST::TobaccoCessation do
     before do
       stub_post("/organizations/1/users/1/tobacco_cessation.json")
         .with(body: { tobacco_cessation: { timestamp: '2013-03-10T07:12:16+00:00', activity_id: '12345' },
-                      access_token: '1' }.to_json)
+                      access_token: '1', organization_id: '1' }.to_json)
         .to_return(body: fixture('tobacco_cessation.json'),
           headers: { content_type: 'application/json; charset=utf-8'} )
     end
@@ -52,7 +52,7 @@ describe Validic::REST::TobaccoCessation do
       expect(a_post('/organizations/1/users/1/tobacco_cessation.json')
         .with(body: { tobacco_cessation: { timestamp: '2013-03-10T07:12:16+00:00',
                                    activity_id: '12345' },
-                      access_token: '1' }.to_json)).to have_been_made
+                      access_token: '1', organization_id: '1' }.to_json)).to have_been_made
     end
     it 'returns a TobaccoCessation' do
       tobacco_cessation = client.create_tobacco_cessation(user_id: '1', timestamp: '2013-03-10T07:12:16+00:00', activity_id: '12345')
@@ -65,7 +65,7 @@ describe Validic::REST::TobaccoCessation do
     before do
       stub_put("/organizations/1/users/1/tobacco_cessation/51552cddfded0807c4000096.json")
         .with(body: { tobacco_cessation: { timestamp: '2013-03-10T07:12:16+00:00' },
-                                   access_token: '1' }.to_json)
+                                   access_token: '1', organization_id: '1' }.to_json)
         .to_return(body: fixture('tobacco_cessation.json'),
                    headers: {content_type: 'application/json; charset=utf-8'})
     end
@@ -73,7 +73,8 @@ describe Validic::REST::TobaccoCessation do
       client.update_tobacco_cessation(user_id: '1', _id: '51552cddfded0807c4000096', timestamp: '2013-03-10T07:12:16+00:00')
       expect(a_put('/organizations/1/users/1/tobacco_cessation/51552cddfded0807c4000096.json')
         .with(body: { tobacco_cessation: { timestamp: '2013-03-10T07:12:16+00:00' },
-                      access_token: '1' }.to_json)).to have_been_made
+                      access_token: '1',
+                      organization_id: '1' }.to_json)).to have_been_made
     end
     it 'returns a TobaccoCessation' do
       tobacco_cessation = client.update_tobacco_cessation(user_id: '1', _id: '51552cddfded0807c4000096', timestamp: '2013-03-10T07:12:16+00:00')
@@ -98,7 +99,7 @@ describe Validic::REST::TobaccoCessation do
     context 'with user_id' do
       before do
         stub_get("/organizations/1/users/2/tobacco_cessation/latest.json").
-          with(query: { access_token: '1' }).
+          with(query: { access_token: '1', organization_id: '1' }).
           to_return(body: fixture('tobacco_cessations.json'),
                     headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -108,13 +109,13 @@ describe Validic::REST::TobaccoCessation do
       end
       it 'builds a latest url' do
         client.latest_tobacco_cessation(user_id: '2')
-        expect(a_get('/organizations/1/users/2/tobacco_cessation/latest.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/users/2/tobacco_cessation/latest.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
     context 'without user_id' do
       before do
         stub_get("/organizations/1/tobacco_cessation/latest.json").
-          with(query: { access_token: '1' }).
+          with(query: { access_token: '1', organization_id: '1' }).
           to_return(body: fixture('tobacco_cessations.json'),
                     headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -124,7 +125,7 @@ describe Validic::REST::TobaccoCessation do
       end
       it 'builds a latest url' do
         client.latest_tobacco_cessation
-        expect(a_get('/organizations/1/tobacco_cessation/latest.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/tobacco_cessation/latest.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
   end

--- a/spec/validic/rest/users_spec.rb
+++ b/spec/validic/rest/users_spec.rb
@@ -6,7 +6,7 @@ describe Validic::REST::Users do
   describe '#get_users' do
     before do
       stub_get("/organizations/1/users.json")
-        .with(query: { access_token: '1' })
+        .with(query: { access_token: '1', organization_id: '1' })
         .to_return(body: fixture('users.json'),
                    headers: { content_type: 'application/json; charset=utf-8' })
     end
@@ -16,20 +16,20 @@ describe Validic::REST::Users do
     end
     it 'makes a users request to the correct url' do
       client.get_users
-      expect(a_get('/organizations/1/users.json').with(query: { access_token: '1' })).to have_been_made
+      expect(a_get('/organizations/1/users.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
     end
   end
 
   describe '#provision_user' do
     before do
       stub_post('/organizations/1/users.json')
-        .with(body: { user: { uid: '123467890' }, access_token: '1' }.to_json)
+        .with(body: { user: { uid: '123467890' }, access_token: '1', organization_id: '1' }.to_json)
         .to_return(body: fixture('user.json'), headers: { content_type: 'application/json; charset=utf-8' })
     end
     it 'requests the correct resource' do
       client.provision_user(uid: '123467890')
       expect(a_post('/organizations/1/users.json')
-        .with(body: { user: { uid: '123467890' }, access_token: '1' }.to_json))
+        .with(body: { user: { uid: '123467890' }, access_token: '1', organization_id: '1' }.to_json))
         .to have_been_made
     end
     it 'returns a User' do
@@ -40,7 +40,7 @@ describe Validic::REST::Users do
     context 'with optional profile' do
       before do
         stub_post('/organizations/1/users.json')
-          .with(body: { user: { uid: '123467890', profile: { gender: 'M' } }, access_token: '1' }.to_json)
+          .with(body: { user: { uid: '123467890', profile: { gender: 'M' } }, access_token: '1', organization_id: '1' }.to_json)
           .to_return(body: fixture('user_with_profile.json'), headers: { content_type: 'application/json; charset=utf-8' })
       end
       it 'returns a User with profile' do
@@ -53,16 +53,30 @@ describe Validic::REST::Users do
     end
   end
 
+  describe '#provision_user to organization 2' do
+    before do
+      stub_post('/organizations/2/users.json')
+        .with(body: { user: { uid: '123467890' }, access_token: "2", organization_id: "2" }.to_json)
+        .to_return(body: fixture('user2.json'), headers: { content_type: 'application/json; charset=utf-8' })
+    end
+    it 'registers a user to the appropriate organization' do
+      user = client.provision_user(uid: '123467890', access_token: "2", organization_id: "2")
+      expect(user.access_token).to eq '2'
+      expect(client.organization_id).to eq '2'
+      expect(client.access_token).to eq '2'
+    end
+  end
+
   describe '#update_user' do
     before do
       stub_put('/organizations/1/users/1.json')
-        .with(body: { user: { uid: 'abcde' }, access_token: '1' }.to_json)
+        .with(body: { user: { uid: 'abcde' }, access_token: '1', organization_id: '1' }.to_json)
         .to_return(body: fixture('updated_user.json'), headers: { content_type: 'application/json; charset=utf-8' })
     end
     it 'requests the correct resource' do
       client.update_user(user_id: '1', uid: 'abcde')
       expect(a_put('/organizations/1/users/1.json')
-        .with(body: { user: { uid: 'abcde' }, access_token: '1' }.to_json))
+        .with(body: { user: { uid: 'abcde' }, access_token: '1', organization_id: '1' }.to_json))
         .to have_been_made
     end
     it 'returns a User' do
@@ -73,7 +87,7 @@ describe Validic::REST::Users do
     context 'with optional profile' do
       before do
         stub_put('/organizations/1/users/1.json')
-          .with(body: { user: { uid: '123467890', profile: { gender: 'M' } }, access_token: '1' }.to_json)
+          .with(body: { user: { uid: '123467890', profile: { gender: 'M' } }, access_token: '1', organization_id: '1' }.to_json)
           .to_return(body: fixture('user_with_profile.json'), headers: { content_type: 'application/json; charset=utf-8' })
       end
       it 'returns a User with profile' do
@@ -98,13 +112,13 @@ describe Validic::REST::Users do
 
   describe '#me' do
     before do
-      stub_get('/me.json').with(query: { access_token: '1', authentication_token: 'auth_token' })
+      stub_get('/me.json').with(query: { access_token: '1', authentication_token: 'auth_token', organization_id: '1' })
         .to_return(body: fixture('me.json'),
             headers: { content_type: 'application/json; charset=utf-8' })
     end
     it 'makes a request to the correct resource' do
       client.me(authentication_token: 'auth_token')
-      expect(a_get('/me.json').with(query: { access_token: '1', authentication_token: 'auth_token' }))
+      expect(a_get('/me.json').with(query: { access_token: '1', authentication_token: 'auth_token', organization_id: '1' }))
         .to have_been_made
     end
     it 'returns a String' do
@@ -116,13 +130,13 @@ describe Validic::REST::Users do
   describe '#suspend_user' do
     before do
       stub_put('/organizations/1/users/1.json')
-        .with(body: { suspend: '1', access_token: '1' }.to_json)
+        .with(body: { suspend: '1', access_token: '1', organization_id: '1' }.to_json)
         .to_return(status: 200)
     end
     it 'makes a request to the correct resource' do
       client.suspend_user(user_id: '1')
       expect(a_put('/organizations/1/users/1.json')
-        .with(body: { suspend: '1', access_token: '1' }.to_json))
+        .with(body: { suspend: '1', access_token: '1', organization_id: '1' }.to_json))
         .to have_been_made
     end
     it 'returns true' do
@@ -134,13 +148,13 @@ describe Validic::REST::Users do
   describe '#unsuspend_user' do
     before do
       stub_put('/organizations/1/users/1.json')
-        .with(body: { suspend: '0', access_token: '1' }.to_json)
+        .with(body: { suspend: '0', access_token: '1', organization_id: '1' }.to_json)
         .to_return(status: 200)
     end
     it 'makes a request to the correct resource' do
       client.unsuspend_user(user_id: '1')
       expect(a_put('/organizations/1/users/1.json')
-        .with(body: { suspend: '0', access_token: '1' }.to_json))
+        .with(body: { suspend: '0', access_token: '1', organization_id: '1' }.to_json))
         .to have_been_made
     end
     it 'returns true' do
@@ -152,14 +166,14 @@ describe Validic::REST::Users do
   describe '#refresh_token' do
     before do
       stub_get('/organizations/1/users/1/refresh_token.json')
-        .with(query: { access_token: '1' })
+        .with(query: { access_token: '1', organization_id: '1' })
         .to_return(body: fixture('refresh_token.json'),
                    headers: { content_type: 'application/json; charset=utf-8' })
     end
     it 'makes a request to the correct resource' do
       client.refresh_token(user_id: '1')
       expect(a_get('/organizations/1/users/1/refresh_token.json')
-        .with(query: { access_token: '1' }))
+        .with(query: { access_token: '1', organization_id: '1' }))
         .to have_been_made
     end
     it 'returns a User' do

--- a/spec/validic/rest/weight_spec.rb
+++ b/spec/validic/rest/weight_spec.rb
@@ -7,7 +7,7 @@ describe Validic::REST::Weight do
     context 'no user_id given' do
       before do
         stub_get("/organizations/1/weight.json")
-          .with(query: { access_token: '1' })
+          .with(query: { access_token: '1', organization_id: '1' })
           .to_return(body: fixture('weights.json'),
         headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -17,13 +17,13 @@ describe Validic::REST::Weight do
       end
       it 'makes a weight request to the correct url' do
         client.get_weight
-        expect(a_get('/organizations/1/weight.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/weight.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
     context 'with user_id' do
       before do
         stub_get("/organizations/1/users/1/weight.json")
-          .with(query: { access_token: '1' })
+          .with(query: { access_token: '1', organization_id: '1' })
           .to_return(body: fixture('weights.json'),
         headers: { content_type: 'application/json; charset=utf-8' })
       end
@@ -33,7 +33,7 @@ describe Validic::REST::Weight do
       end
       it 'makes a weight request to the correct url' do
         client.get_weight(user_id: '1')
-        expect(a_get('/organizations/1/users/1/weight.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/users/1/weight.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
   end
@@ -44,7 +44,7 @@ describe Validic::REST::Weight do
         with(body: { weight: { timestamp: '2013-03-10T07:12:16+00:00',
                                utc_offset: '+00:00', weight: 177,
                                height: 34, data_id: '12345' },
-                               access_token: '1' }.to_json)
+                               access_token: '1', organization_id: '1' }.to_json)
         .to_return(body: fixture('weight.json'),
       headers: { content_type: 'application/json; charset=utf-8'} )
 
@@ -75,7 +75,7 @@ describe Validic::REST::Weight do
                                utc_offset: '+00:00', total_weight: 377,
                                awake: 224, deep: 234, light: 94, rem: 115,
                                times_woken: 4 },
-                               access_token: '1' }.to_json)
+                               access_token: '1', organization_id: '1' }.to_json)
         .to_return(body: fixture('weight.json'),
       headers: {content_type: 'application/json; charset=utf-8'})
 
@@ -118,7 +118,7 @@ describe Validic::REST::Weight do
     context 'with user_id' do
       before do
         stub_get("/organizations/1/users/2/weight/latest.json").
-          with(query: { access_token: '1' }).
+          with(query: { access_token: '1', organization_id: '1' }).
           to_return(body: fixture('weights.json'),
                     headers: { content_type: 'application/json; charset=utf-8' })
           @latest = client.latest_weight(user_id: '2')
@@ -127,13 +127,13 @@ describe Validic::REST::Weight do
         expect(@latest).to be_a Validic::Response
       end
       it 'builds a latest url' do
-        expect(a_get('/organizations/1/users/2/weight/latest.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/users/2/weight/latest.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
     context 'without user_id' do
       before do
         stub_get("/organizations/1/weight/latest.json").
-          with(query: { access_token: '1' }).
+          with(query: { access_token: '1', organization_id: '1' }).
           to_return(body: fixture('weights.json'),
                     headers: { content_type: 'application/json; charset=utf-8' })
           @latest = client.latest_weight
@@ -142,7 +142,7 @@ describe Validic::REST::Weight do
         expect(@latest).to be_a Validic::Response
       end
       it 'builds a latest url' do
-        expect(a_get('/organizations/1/weight/latest.json').with(query: { access_token: '1' })).to have_been_made
+        expect(a_get('/organizations/1/weight/latest.json').with(query: { access_token: '1', organization_id: '1' })).to have_been_made
       end
     end
   end


### PR DESCRIPTION
Acknowledge organization_id and access_token params to access/allot calls to the respective params passed.

Sample:
- This will assign a new user to the organization_id and access_token set as params
client.provision_user(organization_id: 'ORGANIZATION_ID', access_token: 'ACCESS_TOKEN')