### PR TITLE
Use apps.json instead of depracated sync_apps.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+0.5.1
+-----------
+
+- Sync Apps endpoint depracated fix ( https://support.validic.com/customer/portal/articles/2488934-sync-apps-endpoint-deprecation )
+
 0.5.0
 -----------
 - Ability to call the next or previous page from a Validic::Response

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Build Status
 [![Codeship Status for Validic/validic](https://www.codeship.io/projects/cc4ff330-9f72-0130-3cf3-0e5a3e2104f7/status?branch=master)](https://www.codeship.io/projects/3456)
 
-## Stable Version: 0.5.0
+## Stable Version: 0.5.1
 
 Ruby API Wrapper for [Validic](http://www.validic.com/api/docs). It includes the
 following functionality:

--- a/lib/validic/rest/apps.rb
+++ b/lib/validic/rest/apps.rb
@@ -10,8 +10,9 @@ module Validic
       alias :get_apps :get_org_apps
 
       def get_user_synced_apps(options = {})
-        build_response(get_request(:sync_apps,
-                           authentication_token: options[:authentication_token]))
+        build_response(get_request(:apps,
+                           authentication_token: options[:authentication_token],
+                           synced: 1))
       end
       alias :get_synced_apps :get_user_synced_apps
     end

--- a/lib/validic/version.rb
+++ b/lib/validic/version.rb
@@ -1,3 +1,3 @@
 module Validic
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'.freeze
 end

--- a/spec/validic/rest/apps_spec.rb
+++ b/spec/validic/rest/apps_spec.rb
@@ -41,7 +41,7 @@ describe Validic::REST::Apps do
 
   describe '#get_user_synced_apps' do
     before do
-      stub_get('/organizations/1/sync_apps.json')
+      stub_get('/organizations/1/apps.json')
         .with(query: { authentication_token: '2', access_token: '1' })
         .to_return(body: fixture('synced_apps.json'),
       headers: { content_type: 'application/json; charset=utf-8' })
@@ -51,7 +51,7 @@ describe Validic::REST::Apps do
       expect(@synced_apps).to be_a Validic::Response
     end
     it 'makes a sync apps call to the correct url' do
-      expect(a_get('/organizations/1/sync_apps.json')
+      expect(a_get('/organizations/1/apps.json')
         .with(query: { authentication_token: '2', access_token: '1' }))
         .to have_been_made
     end


### PR DESCRIPTION
Please check out Validic depracation warning from using `sync_apps.json` to now use `apps.json`

https://support.validic.com/customer/portal/articles/2488934-sync-apps-endpoint-deprecation