### PR TITLE
Read configuration from validic.yml - railtie approach

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    validic (0.4.1)
-      faraday_middleware (~> 0.9.0)
+    validic (0.5.1)
+      faraday_middleware (~> 0.10)
       multi_json
 
 GEM
@@ -13,12 +13,12 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
-    faraday (0.9.1)
+    faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.9.1)
+    faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
     method_source (0.8.2)
-    multi_json (1.11.0)
+    multi_json (1.12.1)
     multipart-post (2.0.0)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -55,3 +55,6 @@ DEPENDENCIES
   validic!
   webmock (~> 1.20.4)
   yard
+
+BUNDLED WITH
+   1.11.2

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Or install it yourself as:
 ## Usage
 
 ##### Rails 3+
-First, instantiate the client.
+First, instantiate the client via initializers or railtie
+######Initializers
 ```ruby
 require 'validic'
 
@@ -75,10 +76,36 @@ Validic.configure do |config|
   config.organization_id  = 'ORGANIZATION_ID'
 end
 
-# Create a Client Object provided you have an initializer
-client = Validic::Client.new
+```
+######Railtie
+```ruby
+
+# config/validic.yml
+aliases: &common_config
+  api_url: 'https://api.validic.com'
+  api_version: 'v1'
+
+development:
+  << : *common_config
+  validic_acess_token: <%= 'ORGANIZATION_ACCESS_TOKEN' %>
+  validic_organisation_id: <%= 'ORGANIZATION_ID' %>
+
+test:
+  << : *common_config
+  validic_acess_token: <%= 'ORGANIZATION_ACCESS_TOKEN' %>
+  validic_organisation_id: <%= 'ORGANIZATION_ID' %>
+
+production:
+  << : *common_config
+  validic_acess_token: <%= 'ORGANIZATION_ACCESS_TOKEN' %>
+  validic_organisation_id: <%= 'ORGANIZATION_ID' %>
+
 ```
 
+```
+# Create a Client Object provided you have an initializer or validic.yml
+client = Validic::Client.new
+```
 ##### Plain ruby
 ```ruby
 

--- a/lib/validic/client.rb
+++ b/lib/validic/client.rb
@@ -33,7 +33,7 @@ module Validic
     include REST::TobaccoCessation
     include REST::Users
     include REST::Weight
-
+    require 'validic/rails/railtie'
     attr_accessor :api_url,
       :api_version,
       :access_token,
@@ -44,11 +44,13 @@ module Validic
     #
     # @params options[Hash]
     def initialize(options={})
-      @api_url          = options.fetch(:api_url, 'https://api.validic.com')
-      @api_version      = options.fetch(:api_version, 'v1')
-      @access_token     = options.fetch(:access_token, Validic.access_token)
-      @organization_id  = options.fetch(:organization_id, Validic.organization_id)
-      reload_config
+      if (Validic.api_url.nil? || Validic.api_version.nil? || Validic.access_token.nil? || Validic.organization_id.nil?)
+        @api_url          = options.fetch(:api_url, 'https://api.validic.com')
+        @api_version      = options.fetch(:api_version, 'v1')
+        @access_token     = options.fetch(:access_token, Validic.access_token)
+        @organization_id  = options.fetch(:organization_id, Validic.organization_id)
+        reload_config
+      end
     end
 
     ##
@@ -56,7 +58,7 @@ module Validic
     #
     # @return [Faraday::Connection]
     def connection
-      Faraday.new(url: @api_url, headers: default_headers, ssl: { verify: true }) do |faraday|
+      Faraday.new(url: Validic.api_url, headers: default_headers, ssl: { verify: true }) do |faraday|
         # faraday.use FaradayMiddleware::Mashify
         faraday.use FaradayMiddleware::ParseJson, content_type: /\bjson$/
         faraday.use FaradayMiddleware::FollowRedirects
@@ -75,10 +77,10 @@ module Validic
     end
 
     def reload_config
-      Validic.api_url = api_url
-      Validic.api_version = api_version
-      Validic.access_token = access_token
-      Validic.organization_id = organization_id
+      Validic.api_url = @api_url
+      Validic.api_version = @api_version
+      Validic.access_token = @access_token
+      Validic.organization_id = @organization_id
     end
   end
 end

--- a/lib/validic/rails/railtie.rb
+++ b/lib/validic/rails/railtie.rb
@@ -1,0 +1,18 @@
+module Validic
+  class Railtie < ::Rails::Railtie
+    config.before_initialize do
+      begin
+        VALIDIC_CONFIG = Rails.application.config_for(:validic)
+
+        Validic.configure do |validic|
+          validic.api_url         = VALIDIC_CONFIG['api_url']
+          validic.api_version     = VALIDIC_CONFIG['api_version']
+          validic.access_token    = VALIDIC_CONFIG['validic_acess_token']
+          validic.organization_id = VALIDIC_CONFIG['validic_organisation_id']
+        end
+      rescue
+        raise MissingConfiguration, 'You must define a validic.yml config file in the rails app'
+      end
+    end
+  end
+end

--- a/validic.gemspec
+++ b/validic.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'faraday_middleware', '~> 0.9.0'
+  spec.add_dependency 'faraday_middleware', '~> 0.10'
   spec.add_dependency 'multi_json'
   spec.add_development_dependency "bundler"
 end


### PR DESCRIPTION
Providing an option to consumer to declare configuration in validic yml so that they can maintain different validic token with respect to their environments.