### PR TITLE
Include travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+rvm:
+  - 2.5.0
+  - 2.4.3
+  - 2.3.6
+before_install: gem install bundler -v 1.16.0
+script:
+  - bundle exec rspec


### PR DESCRIPTION
Since you are using codeship and it works internally for your team, I thought that for the rest of the community it's a nice to have **travis-ci** as a tool where we can see if to know if everything works in different ruby versions. 